### PR TITLE
CTP-3690 correct tags for PHPDocs CI

### DIFF
--- a/actions/ajax/datatable/grading.php
+++ b/actions/ajax/datatable/grading.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/ajax/datatable/grading.php
+++ b/actions/ajax/datatable/grading.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/ajax/deadline_extension/edit.php
+++ b/actions/ajax/deadline_extension/edit.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/ajax/deadline_extension/edit.php
+++ b/actions/ajax/deadline_extension/edit.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/ajax/deadline_extension/new.php
+++ b/actions/ajax/deadline_extension/new.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/ajax/deadline_extension/new.php
+++ b/actions/ajax/deadline_extension/new.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/ajax/deadline_extension/submit.php
+++ b/actions/ajax/deadline_extension/submit.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/ajax/deadline_extension/submit.php
+++ b/actions/ajax/deadline_extension/submit.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/allocate.php
+++ b/actions/allocate.php
@@ -19,7 +19,7 @@
  * etc can be allocated manually or automatically.
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/allocate.php
+++ b/actions/allocate.php
@@ -19,7 +19,7 @@
  * etc can be allocated manually or automatically.
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/allocationsession.php
+++ b/actions/allocationsession.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/allocationsession.php
+++ b/actions/allocationsession.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/deadline_extensions/create.php
+++ b/actions/deadline_extensions/create.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/deadline_extensions/create.php
+++ b/actions/deadline_extensions/create.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/deadline_extensions/edit.php
+++ b/actions/deadline_extensions/edit.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/deadline_extensions/edit.php
+++ b/actions/deadline_extensions/edit.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/deadline_extensions/new.php
+++ b/actions/deadline_extensions/new.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/deadline_extensions/new.php
+++ b/actions/deadline_extensions/new.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/deadline_extensions/show.php
+++ b/actions/deadline_extensions/show.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/deadline_extensions/show.php
+++ b/actions/deadline_extensions/show.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/deadline_extensions/update.php
+++ b/actions/deadline_extensions/update.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/deadline_extensions/update.php
+++ b/actions/deadline_extensions/update.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/feedbacks/create.php
+++ b/actions/feedbacks/create.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/feedbacks/create.php
+++ b/actions/feedbacks/create.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/feedbacks/edit.php
+++ b/actions/feedbacks/edit.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2014 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2014 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/feedbacks/edit.php
+++ b/actions/feedbacks/edit.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2014 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2014 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/feedbacks/new.php
+++ b/actions/feedbacks/new.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/feedbacks/new.php
+++ b/actions/feedbacks/new.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/feedbacks/show.php
+++ b/actions/feedbacks/show.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/feedbacks/show.php
+++ b/actions/feedbacks/show.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/feedbacks/update.php
+++ b/actions/feedbacks/update.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/feedbacks/update.php
+++ b/actions/feedbacks/update.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/finalgrade.php
+++ b/actions/finalgrade.php
@@ -18,7 +18,7 @@
  * This file displays a moodle form used to create a final grade for a submission
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/finalgrade.php
+++ b/actions/finalgrade.php
@@ -18,7 +18,7 @@
  * This file displays a moodle form used to create a final grade for a submission
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/general_feedback.php
+++ b/actions/general_feedback.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2011 University of London computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/general_feedback.php
+++ b/actions/general_feedback.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2011 University of London computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/moderations/create.php
+++ b/actions/moderations/create.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/moderations/create.php
+++ b/actions/moderations/create.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/moderations/edit.php
+++ b/actions/moderations/edit.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/moderations/edit.php
+++ b/actions/moderations/edit.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/moderations/new.php
+++ b/actions/moderations/new.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/moderations/new.php
+++ b/actions/moderations/new.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/moderations/show.php
+++ b/actions/moderations/show.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2018 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2018 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/moderations/show.php
+++ b/actions/moderations/show.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2018 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2018 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/moderations/update.php
+++ b/actions/moderations/update.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/moderations/update.php
+++ b/actions/moderations/update.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/personal_deadline.php
+++ b/actions/personal_deadline.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/personal_deadline.php
+++ b/actions/personal_deadline.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/plagiarism_flagging/create.php
+++ b/actions/plagiarism_flagging/create.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/plagiarism_flagging/create.php
+++ b/actions/plagiarism_flagging/create.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/plagiarism_flagging/edit.php
+++ b/actions/plagiarism_flagging/edit.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2018 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2018 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/plagiarism_flagging/edit.php
+++ b/actions/plagiarism_flagging/edit.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2018 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2018 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/plagiarism_flagging/new.php
+++ b/actions/plagiarism_flagging/new.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2018 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2018 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/plagiarism_flagging/new.php
+++ b/actions/plagiarism_flagging/new.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2018 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2018 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/plagiarism_flagging/update.php
+++ b/actions/plagiarism_flagging/update.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/plagiarism_flagging/update.php
+++ b/actions/plagiarism_flagging/update.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/processallocation.php
+++ b/actions/processallocation.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/processallocation.php
+++ b/actions/processallocation.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/revert.php
+++ b/actions/revert.php
@@ -19,7 +19,7 @@
  * files again. Not allowed if they already have feedbacks
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/revert.php
+++ b/actions/revert.php
@@ -19,7 +19,7 @@
  * files again. Not allowed if they already have feedbacks
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/selectallallocatables.php
+++ b/actions/selectallallocatables.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/selectallallocatables.php
+++ b/actions/selectallallocatables.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/set_personal_deadlines.php
+++ b/actions/set_personal_deadlines.php
@@ -18,7 +18,7 @@
  * Page that prints a table of all students and their personal deadlines in order to change it one by  one or in bulk .
  *
  * @package    mod_coursework
- * @copyright  2016 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2016 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/set_personal_deadlines.php
+++ b/actions/set_personal_deadlines.php
@@ -18,7 +18,7 @@
  * Page that prints a table of all students and their personal deadlines in order to change it one by  one or in bulk .
  *
  * @package    mod_coursework
- * @copyright  2016 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2016 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/submissions/create.php
+++ b/actions/submissions/create.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/submissions/create.php
+++ b/actions/submissions/create.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/submissions/edit.php
+++ b/actions/submissions/edit.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/submissions/edit.php
+++ b/actions/submissions/edit.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/submissions/finalise.php
+++ b/actions/submissions/finalise.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/submissions/finalise.php
+++ b/actions/submissions/finalise.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/submissions/new.php
+++ b/actions/submissions/new.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/submissions/new.php
+++ b/actions/submissions/new.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/submissions/update.php
+++ b/actions/submissions/update.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/submissions/update.php
+++ b/actions/submissions/update.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/submitonbehalfofstudent.php
+++ b/actions/submitonbehalfofstudent.php
@@ -19,7 +19,7 @@
  * who may have problems with their internet access, or who cannot for some reason work out how to use the submission form.
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/submitonbehalfofstudent.php
+++ b/actions/submitonbehalfofstudent.php
@@ -19,7 +19,7 @@
  * who may have problems with their internet access, or who cannot for some reason work out how to use the submission form.
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/upload_allocations.php
+++ b/actions/upload_allocations.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2016 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2016 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/upload_allocations.php
+++ b/actions/upload_allocations.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2016 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2016 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/upload_feedback.php
+++ b/actions/upload_feedback.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/upload_feedback.php
+++ b/actions/upload_feedback.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/upload_grading_sheet.php
+++ b/actions/upload_grading_sheet.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/actions/upload_grading_sheet.php
+++ b/actions/upload_grading_sheet.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/backup/moodle2/backup_coursework_activity_task.class.php
+++ b/backup/moodle2/backup_coursework_activity_task.class.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/backup/moodle2/backup_coursework_activity_task.class.php
+++ b/backup/moodle2/backup_coursework_activity_task.class.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/backup/moodle2/backup_coursework_stepslib.php
+++ b/backup/moodle2/backup_coursework_stepslib.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/backup/moodle2/backup_coursework_stepslib.php
+++ b/backup/moodle2/backup_coursework_stepslib.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/backup/moodle2/restore_coursework_activity_task.class.php
+++ b/backup/moodle2/restore_coursework_activity_task.class.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/backup/moodle2/restore_coursework_activity_task.class.php
+++ b/backup/moodle2/restore_coursework_activity_task.class.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/backup/moodle2/restore_coursework_stepslib.php
+++ b/backup/moodle2/restore_coursework_stepslib.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/backup/moodle2/restore_coursework_stepslib.php
+++ b/backup/moodle2/restore_coursework_stepslib.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/ability.php
+++ b/classes/ability.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/ability.php
+++ b/classes/ability.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/ability/rule.php
+++ b/classes/ability/rule.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/ability/rule.php
+++ b/classes/ability/rule.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/allocatable.php
+++ b/classes/allocation/allocatable.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/allocatable.php
+++ b/classes/allocation/allocatable.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/auto_allocator.php
+++ b/classes/allocation/auto_allocator.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/auto_allocator.php
+++ b/classes/allocation/auto_allocator.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/manager.php
+++ b/classes/allocation/manager.php
@@ -21,7 +21,7 @@ namespace mod_coursework\allocation;
  * moderators etc can be allocated manually or automatically.
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/manager.php
+++ b/classes/allocation/manager.php
@@ -21,7 +21,7 @@ namespace mod_coursework\allocation;
  * moderators etc can be allocated manually or automatically.
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/moderatable.php
+++ b/classes/allocation/moderatable.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/moderatable.php
+++ b/classes/allocation/moderatable.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/strategy/base.php
+++ b/classes/allocation/strategy/base.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/strategy/base.php
+++ b/classes/allocation/strategy/base.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/strategy/equal.php
+++ b/classes/allocation/strategy/equal.php
@@ -20,7 +20,7 @@ namespace mod_coursework\allocation\strategy;
  * Allocation strategy for giving all teachers equal numbers of students to mark
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/strategy/equal.php
+++ b/classes/allocation/strategy/equal.php
@@ -20,7 +20,7 @@ namespace mod_coursework\allocation\strategy;
  * Allocation strategy for giving all teachers equal numbers of students to mark
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/strategy/group_assessor.php
+++ b/classes/allocation/strategy/group_assessor.php
@@ -20,7 +20,7 @@ namespace mod_coursework\allocation\strategy;
  * Class file for the Group assessor allocation strategy.
  *
  * @package    mod_coursework
- * @copyright  2018 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2018 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/strategy/group_assessor.php
+++ b/classes/allocation/strategy/group_assessor.php
@@ -20,7 +20,7 @@ namespace mod_coursework\allocation\strategy;
  * Class file for the Group assessor allocation strategy.
  *
  * @package    mod_coursework
- * @copyright  2018 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2018 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/strategy/none.php
+++ b/classes/allocation/strategy/none.php
@@ -20,7 +20,7 @@ namespace mod_coursework\allocation\strategy;
  * lass file for the default allocation strategy.
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/strategy/none.php
+++ b/classes/allocation/strategy/none.php
@@ -20,7 +20,7 @@ namespace mod_coursework\allocation\strategy;
  * lass file for the default allocation strategy.
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/strategy/percentages.php
+++ b/classes/allocation/strategy/percentages.php
@@ -20,7 +20,7 @@ namespace mod_coursework\allocation\strategy;
  * Allocation strategy for giving each teacher a different percentage of work to mark.
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/strategy/percentages.php
+++ b/classes/allocation/strategy/percentages.php
@@ -20,7 +20,7 @@ namespace mod_coursework\allocation\strategy;
  * Allocation strategy for giving each teacher a different percentage of work to mark.
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/table/builder.php
+++ b/classes/allocation/table/builder.php
@@ -20,7 +20,7 @@ namespace mod_coursework\allocation\table;
  * Class file for the renderable object that makes the table for allocating markerts to students.
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/table/builder.php
+++ b/classes/allocation/table/builder.php
@@ -20,7 +20,7 @@ namespace mod_coursework\allocation\table;
  * Class file for the renderable object that makes the table for allocating markerts to students.
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/table/cell/builder.php
+++ b/classes/allocation/table/cell/builder.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/table/cell/builder.php
+++ b/classes/allocation/table/cell/builder.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/table/cell/data.php
+++ b/classes/allocation/table/cell/data.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/table/cell/data.php
+++ b/classes/allocation/table/cell/data.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/table/cell/processor.php
+++ b/classes/allocation/table/cell/processor.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/table/cell/processor.php
+++ b/classes/allocation/table/cell/processor.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/table/processor.php
+++ b/classes/allocation/table/processor.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/table/processor.php
+++ b/classes/allocation/table/processor.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/table/row/builder.php
+++ b/classes/allocation/table/row/builder.php
@@ -20,7 +20,7 @@ namespace mod_coursework\allocation\table\row;
  * Class file for the renderable object that makes a single row in the marker allocation table.
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/table/row/builder.php
+++ b/classes/allocation/table/row/builder.php
@@ -20,7 +20,7 @@ namespace mod_coursework\allocation\table\row;
  * Class file for the renderable object that makes a single row in the marker allocation table.
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/table/row/processor.php
+++ b/classes/allocation/table/row/processor.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/table/row/processor.php
+++ b/classes/allocation/table/row/processor.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/upload.php
+++ b/classes/allocation/upload.php
@@ -20,7 +20,7 @@ use mod_coursework\models;
 
 /**
  * @package    mod_coursework
- * @copyright  2016 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2016 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/upload.php
+++ b/classes/allocation/upload.php
@@ -20,7 +20,7 @@ use mod_coursework\models;
 
 /**
  * @package    mod_coursework
- * @copyright  2016 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2016 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/widget.php
+++ b/classes/allocation/widget.php
@@ -20,7 +20,7 @@ namespace mod_coursework\allocation;
  * Rendererable object to make the widget to choose allocation strategy.
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/allocation/widget.php
+++ b/classes/allocation/widget.php
@@ -20,7 +20,7 @@ namespace mod_coursework\allocation;
  * Rendererable object to make the widget to choose allocation strategy.
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/assessor_feedback_row.php
+++ b/classes/assessor_feedback_row.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/assessor_feedback_row.php
+++ b/classes/assessor_feedback_row.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/assessor_feedback_table.php
+++ b/classes/assessor_feedback_table.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/assessor_feedback_table.php
+++ b/classes/assessor_feedback_table.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/auto_grader/auto_grader.php
+++ b/classes/auto_grader/auto_grader.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/auto_grader/auto_grader.php
+++ b/classes/auto_grader/auto_grader.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/auto_grader/average_grade.php
+++ b/classes/auto_grader/average_grade.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/auto_grader/average_grade.php
+++ b/classes/auto_grader/average_grade.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/auto_grader/none.php
+++ b/classes/auto_grader/none.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/auto_grader/none.php
+++ b/classes/auto_grader/none.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/auto_grader/percentage_distance.php
+++ b/classes/auto_grader/percentage_distance.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/auto_grader/percentage_distance.php
+++ b/classes/auto_grader/percentage_distance.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/controllers/allocations_controller.php
+++ b/classes/controllers/allocations_controller.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/controllers/allocations_controller.php
+++ b/classes/controllers/allocations_controller.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/controllers/controller_base.php
+++ b/classes/controllers/controller_base.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/controllers/controller_base.php
+++ b/classes/controllers/controller_base.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/controllers/deadline_extensions_controller.php
+++ b/classes/controllers/deadline_extensions_controller.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/controllers/deadline_extensions_controller.php
+++ b/classes/controllers/deadline_extensions_controller.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/controllers/feedback_controller.php
+++ b/classes/controllers/feedback_controller.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/controllers/feedback_controller.php
+++ b/classes/controllers/feedback_controller.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/controllers/grading_controller.php
+++ b/classes/controllers/grading_controller.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/controllers/grading_controller.php
+++ b/classes/controllers/grading_controller.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/controllers/moderations_controller.php
+++ b/classes/controllers/moderations_controller.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/controllers/moderations_controller.php
+++ b/classes/controllers/moderations_controller.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/controllers/personal_deadlines_controller.php
+++ b/classes/controllers/personal_deadlines_controller.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/controllers/personal_deadlines_controller.php
+++ b/classes/controllers/personal_deadlines_controller.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/controllers/plagiarism_flagging_controller.php
+++ b/classes/controllers/plagiarism_flagging_controller.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/controllers/plagiarism_flagging_controller.php
+++ b/classes/controllers/plagiarism_flagging_controller.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/controllers/submissions_controller.php
+++ b/classes/controllers/submissions_controller.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/controllers/submissions_controller.php
+++ b/classes/controllers/submissions_controller.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/cron.php
+++ b/classes/cron.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/cron.php
+++ b/classes/cron.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/decorators/coursework_groups_decorator.php
+++ b/classes/decorators/coursework_groups_decorator.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/decorators/coursework_groups_decorator.php
+++ b/classes/decorators/coursework_groups_decorator.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/decorators/submission_groups_decorator.php
+++ b/classes/decorators/submission_groups_decorator.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/decorators/submission_groups_decorator.php
+++ b/classes/decorators/submission_groups_decorator.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/event/assessable_uploaded.php
+++ b/classes/event/assessable_uploaded.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/event/assessable_uploaded.php
+++ b/classes/event/assessable_uploaded.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/event/course_module_instance_list_viewed.php
+++ b/classes/event/course_module_instance_list_viewed.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/event/course_module_instance_list_viewed.php
+++ b/classes/event/course_module_instance_list_viewed.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/event/course_module_viewed.php
+++ b/classes/event/course_module_viewed.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/event/course_module_viewed.php
+++ b/classes/event/course_module_viewed.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/event/coursework_deadline_changed.php
+++ b/classes/event/coursework_deadline_changed.php
@@ -18,7 +18,7 @@
  * coursework_deadline_changed
  *
  * @package    mod_coursework
- * @copyright  2016 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2016 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/event/coursework_deadline_changed.php
+++ b/classes/event/coursework_deadline_changed.php
@@ -18,7 +18,7 @@
  * coursework_deadline_changed
  *
  * @package    mod_coursework
- * @copyright  2016 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2016 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/event/coursework_plagiarism_flag_updated.php
+++ b/classes/event/coursework_plagiarism_flag_updated.php
@@ -18,7 +18,7 @@
  * ccoursework_plagiarism_flag_updated
  *
  * @package    mod_coursework
- * @copyright  2016 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2016 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/event/coursework_plagiarism_flag_updated.php
+++ b/classes/event/coursework_plagiarism_flag_updated.php
@@ -18,7 +18,7 @@
  * ccoursework_plagiarism_flag_updated
  *
  * @package    mod_coursework
- * @copyright  2016 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2016 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/event/feedback_changed.php
+++ b/classes/event/feedback_changed.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/event/feedback_changed.php
+++ b/classes/event/feedback_changed.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/exceptions/access_denied.php
+++ b/classes/exceptions/access_denied.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/exceptions/access_denied.php
+++ b/classes/exceptions/access_denied.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/exceptions/late_submission.php
+++ b/classes/exceptions/late_submission.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/exceptions/late_submission.php
+++ b/classes/exceptions/late_submission.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv.php
+++ b/classes/export/csv.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv.php
+++ b/classes/export/csv.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/agreedfeedback_cell.php
+++ b/classes/export/csv/cells/agreedfeedback_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/agreedfeedback_cell.php
+++ b/classes/export/csv/cells/agreedfeedback_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/agreedgrade_cell.php
+++ b/classes/export/csv/cells/agreedgrade_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/agreedgrade_cell.php
+++ b/classes/export/csv/cells/agreedgrade_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/assessor_cell.php
+++ b/classes/export/csv/cells/assessor_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/assessor_cell.php
+++ b/classes/export/csv/cells/assessor_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/assessorfeedback_cell.php
+++ b/classes/export/csv/cells/assessorfeedback_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/assessorfeedback_cell.php
+++ b/classes/export/csv/cells/assessorfeedback_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/assessorgrade_cell.php
+++ b/classes/export/csv/cells/assessorgrade_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/assessorgrade_cell.php
+++ b/classes/export/csv/cells/assessorgrade_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/cell_base.php
+++ b/classes/export/csv/cells/cell_base.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/cell_base.php
+++ b/classes/export/csv/cells/cell_base.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/cell_interface.php
+++ b/classes/export/csv/cells/cell_interface.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/cell_interface.php
+++ b/classes/export/csv/cells/cell_interface.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/email_cell.php
+++ b/classes/export/csv/cells/email_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/email_cell.php
+++ b/classes/export/csv/cells/email_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/extensiondeadline_cell.php
+++ b/classes/export/csv/cells/extensiondeadline_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/extensiondeadline_cell.php
+++ b/classes/export/csv/cells/extensiondeadline_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/extensionextrainfo_cell.php
+++ b/classes/export/csv/cells/extensionextrainfo_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/extensionextrainfo_cell.php
+++ b/classes/export/csv/cells/extensionextrainfo_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/extensionreason_cell.php
+++ b/classes/export/csv/cells/extensionreason_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/extensionreason_cell.php
+++ b/classes/export/csv/cells/extensionreason_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/feedbackcomments_cell.php
+++ b/classes/export/csv/cells/feedbackcomments_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/feedbackcomments_cell.php
+++ b/classes/export/csv/cells/feedbackcomments_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/finalgrade_cell.php
+++ b/classes/export/csv/cells/finalgrade_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/finalgrade_cell.php
+++ b/classes/export/csv/cells/finalgrade_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/group_cell.php
+++ b/classes/export/csv/cells/group_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/group_cell.php
+++ b/classes/export/csv/cells/group_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/idnumber_cell.php
+++ b/classes/export/csv/cells/idnumber_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/idnumber_cell.php
+++ b/classes/export/csv/cells/idnumber_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/moderationagreement_cell.php
+++ b/classes/export/csv/cells/moderationagreement_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/moderationagreement_cell.php
+++ b/classes/export/csv/cells/moderationagreement_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/name_cell.php
+++ b/classes/export/csv/cells/name_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/name_cell.php
+++ b/classes/export/csv/cells/name_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/otherassessors_cell.php
+++ b/classes/export/csv/cells/otherassessors_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/otherassessors_cell.php
+++ b/classes/export/csv/cells/otherassessors_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/personaldeadline_cell.php
+++ b/classes/export/csv/cells/personaldeadline_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/personaldeadline_cell.php
+++ b/classes/export/csv/cells/personaldeadline_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/plagiarismflagcomment_cell.php
+++ b/classes/export/csv/cells/plagiarismflagcomment_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/plagiarismflagcomment_cell.php
+++ b/classes/export/csv/cells/plagiarismflagcomment_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/plagiarismflagstatus_cell.php
+++ b/classes/export/csv/cells/plagiarismflagstatus_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/plagiarismflagstatus_cell.php
+++ b/classes/export/csv/cells/plagiarismflagstatus_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/singlegrade_cell.php
+++ b/classes/export/csv/cells/singlegrade_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/singlegrade_cell.php
+++ b/classes/export/csv/cells/singlegrade_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/stages_cell.php
+++ b/classes/export/csv/cells/stages_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/stages_cell.php
+++ b/classes/export/csv/cells/stages_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/submissiondate_cell.php
+++ b/classes/export/csv/cells/submissiondate_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/submissiondate_cell.php
+++ b/classes/export/csv/cells/submissiondate_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/submissionfileid_cell.php
+++ b/classes/export/csv/cells/submissionfileid_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/submissionfileid_cell.php
+++ b/classes/export/csv/cells/submissionfileid_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/submissionid_cell.php
+++ b/classes/export/csv/cells/submissionid_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/submissionid_cell.php
+++ b/classes/export/csv/cells/submissionid_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/submissiontime_cell.php
+++ b/classes/export/csv/cells/submissiontime_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/submissiontime_cell.php
+++ b/classes/export/csv/cells/submissiontime_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/username_cell.php
+++ b/classes/export/csv/cells/username_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/csv/cells/username_cell.php
+++ b/classes/export/csv/cells/username_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/grading_sheet.php
+++ b/classes/export/grading_sheet.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/grading_sheet.php
+++ b/classes/export/grading_sheet.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/import.php
+++ b/classes/export/import.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/export/import.php
+++ b/classes/export/import.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/feedback_files.php
+++ b/classes/feedback_files.php
@@ -20,7 +20,7 @@ namespace mod_coursework;
  * Displays the information a student sees when they submit or have submitted work
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/feedback_files.php
+++ b/classes/feedback_files.php
@@ -20,7 +20,7 @@ namespace mod_coursework;
  * Displays the information a student sees when they submit or have submitted work
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/file_importer.php
+++ b/classes/file_importer.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/file_importer.php
+++ b/classes/file_importer.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/files.php
+++ b/classes/files.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/files.php
+++ b/classes/files.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/advance_plugins_form.php
+++ b/classes/forms/advance_plugins_form.php
@@ -18,7 +18,7 @@
  * Creates an mform for final grade
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/advance_plugins_form.php
+++ b/classes/forms/advance_plugins_form.php
@@ -18,7 +18,7 @@
  * Creates an mform for final grade
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/assessor_feedback_mform.php
+++ b/classes/forms/assessor_feedback_mform.php
@@ -18,7 +18,7 @@
  * Creates an mform for final grade
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/assessor_feedback_mform.php
+++ b/classes/forms/assessor_feedback_mform.php
@@ -18,7 +18,7 @@
  * Creates an mform for final grade
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/deadline_extension_form.php
+++ b/classes/forms/deadline_extension_form.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/deadline_extension_form.php
+++ b/classes/forms/deadline_extension_form.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/general_feedback_form.php
+++ b/classes/forms/general_feedback_form.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/general_feedback_form.php
+++ b/classes/forms/general_feedback_form.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/moderator_agreement_mform.php
+++ b/classes/forms/moderator_agreement_mform.php
@@ -18,7 +18,7 @@
  * Creates an mform for moderator agreement
  *
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/moderator_agreement_mform.php
+++ b/classes/forms/moderator_agreement_mform.php
@@ -18,7 +18,7 @@
  * Creates an mform for moderator agreement
  *
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/personal_deadline_form.php
+++ b/classes/forms/personal_deadline_form.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/personal_deadline_form.php
+++ b/classes/forms/personal_deadline_form.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/plagiarism_flagging_mform.php
+++ b/classes/forms/plagiarism_flagging_mform.php
@@ -18,7 +18,7 @@
  * Creates an mform for moderator agreement
  *
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/plagiarism_flagging_mform.php
+++ b/classes/forms/plagiarism_flagging_mform.php
@@ -18,7 +18,7 @@
  * Creates an mform for moderator agreement
  *
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/publish_form.php
+++ b/classes/forms/publish_form.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/publish_form.php
+++ b/classes/forms/publish_form.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/student_submission_form.php
+++ b/classes/forms/student_submission_form.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/student_submission_form.php
+++ b/classes/forms/student_submission_form.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/upload_allocations_form.php
+++ b/classes/forms/upload_allocations_form.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2016 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2016 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/upload_allocations_form.php
+++ b/classes/forms/upload_allocations_form.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2016 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2016 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/upload_feedback_form.php
+++ b/classes/forms/upload_feedback_form.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/upload_feedback_form.php
+++ b/classes/forms/upload_feedback_form.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/upload_grading_sheet_form.php
+++ b/classes/forms/upload_grading_sheet_form.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/upload_grading_sheet_form.php
+++ b/classes/forms/upload_grading_sheet_form.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/view_all_students_mform.php
+++ b/classes/forms/view_all_students_mform.php
@@ -17,7 +17,7 @@
 /**
  * This is a mform designed to allow the toggling of the displaying of students not allocated to the current user
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/forms/view_all_students_mform.php
+++ b/classes/forms/view_all_students_mform.php
@@ -17,7 +17,7 @@
 /**
  * This is a mform designed to allow the toggling of the displaying of students not allocated to the current user
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/framework/ability.php
+++ b/classes/framework/ability.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/framework/ability.php
+++ b/classes/framework/ability.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/framework/decorator.php
+++ b/classes/framework/decorator.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/framework/decorator.php
+++ b/classes/framework/decorator.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/framework/table_base.php
+++ b/classes/framework/table_base.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/framework/table_base.php
+++ b/classes/framework/table_base.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/framework/test/classes/user_table.php
+++ b/classes/framework/test/classes/user_table.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/framework/test/classes/user_table.php
+++ b/classes/framework/test/classes/user_table.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/framework/test/table_base_test.php
+++ b/classes/framework/test/table_base_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/framework/test/table_base_test.php
+++ b/classes/framework/test/table_base_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/grade_judge.php
+++ b/classes/grade_judge.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/grade_judge.php
+++ b/classes/grade_judge.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/grades/gradeitems.php
+++ b/classes/grades/gradeitems.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/grades/gradeitems.php
+++ b/classes/grades/gradeitems.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/grading_report.php
+++ b/classes/grading_report.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/grading_report.php
+++ b/classes/grading_report.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/grading_table_row_base.php
+++ b/classes/grading_table_row_base.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/grading_table_row_base.php
+++ b/classes/grading_table_row_base.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/grading_table_row_multi.php
+++ b/classes/grading_table_row_multi.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/grading_table_row_multi.php
+++ b/classes/grading_table_row_multi.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/grading_table_row_single.php
+++ b/classes/grading_table_row_single.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/grading_table_row_single.php
+++ b/classes/grading_table_row_single.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/mailer.php
+++ b/classes/mailer.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/mailer.php
+++ b/classes/mailer.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/allocation.php
+++ b/classes/models/allocation.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/allocation.php
+++ b/classes/models/allocation.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/assessment_set_membership.php
+++ b/classes/models/assessment_set_membership.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/assessment_set_membership.php
+++ b/classes/models/assessment_set_membership.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/course_module.php
+++ b/classes/models/course_module.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/course_module.php
+++ b/classes/models/course_module.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/deadline_extension.php
+++ b/classes/models/deadline_extension.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/deadline_extension.php
+++ b/classes/models/deadline_extension.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/feedback.php
+++ b/classes/models/feedback.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/feedback.php
+++ b/classes/models/feedback.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/group.php
+++ b/classes/models/group.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/group.php
+++ b/classes/models/group.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/moderation.php
+++ b/classes/models/moderation.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/moderation.php
+++ b/classes/models/moderation.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/moderation_set_rule.php
+++ b/classes/models/moderation_set_rule.php
@@ -30,7 +30,7 @@ use mod_coursework\stages\base as stage_base;
  * here will all be database-neutral, using the functions defined in DLL libraries.
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/moderation_set_rule.php
+++ b/classes/models/moderation_set_rule.php
@@ -30,7 +30,7 @@ use mod_coursework\stages\base as stage_base;
  * here will all be database-neutral, using the functions defined in DLL libraries.
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/module.php
+++ b/classes/models/module.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/module.php
+++ b/classes/models/module.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/null_feedback.php
+++ b/classes/models/null_feedback.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/null_feedback.php
+++ b/classes/models/null_feedback.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/null_user.php
+++ b/classes/models/null_user.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/null_user.php
+++ b/classes/models/null_user.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/outstanding_marking.php
+++ b/classes/models/outstanding_marking.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/outstanding_marking.php
+++ b/classes/models/outstanding_marking.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/personal_deadline.php
+++ b/classes/models/personal_deadline.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/personal_deadline.php
+++ b/classes/models/personal_deadline.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/plagiarism_flag.php
+++ b/classes/models/plagiarism_flag.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/plagiarism_flag.php
+++ b/classes/models/plagiarism_flag.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/reminder.php
+++ b/classes/models/reminder.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/reminder.php
+++ b/classes/models/reminder.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/sample_set_rule.php
+++ b/classes/models/sample_set_rule.php
@@ -30,7 +30,7 @@ use mod_coursework\stages\base as stage_base;
  * here will all be database-neutral, using the functions defined in DLL libraries.
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/sample_set_rule.php
+++ b/classes/models/sample_set_rule.php
@@ -30,7 +30,7 @@ use mod_coursework\stages\base as stage_base;
  * here will all be database-neutral, using the functions defined in DLL libraries.
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/submission.php
+++ b/classes/models/submission.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/submission.php
+++ b/classes/models/submission.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/user.php
+++ b/classes/models/user.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/models/user.php
+++ b/classes/models/user.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/moderation_set_rule/minimum_range_grade_percent.php
+++ b/classes/moderation_set_rule/minimum_range_grade_percent.php
@@ -18,7 +18,7 @@
  * File for a moderation set rule that will include X students from between an upper and lower limit.
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/moderation_set_rule/minimum_range_grade_percent.php
+++ b/classes/moderation_set_rule/minimum_range_grade_percent.php
@@ -18,7 +18,7 @@
  * File for a moderation set rule that will include X students from between an upper and lower limit.
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/moderation_set_rule/minimum_range_grade_raw.php
+++ b/classes/moderation_set_rule/minimum_range_grade_raw.php
@@ -18,7 +18,7 @@
  * File for a moderation set rule that will include X students from between an upper and lower limit.
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/moderation_set_rule/minimum_range_grade_raw.php
+++ b/classes/moderation_set_rule/minimum_range_grade_raw.php
@@ -18,7 +18,7 @@
  * File for a moderation set rule that will include X students from between an upper and lower limit.
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/moderation_set_rule/range_grade_percent.php
+++ b/classes/moderation_set_rule/range_grade_percent.php
@@ -19,7 +19,7 @@
  * moderators etc can be allocated manually or automatically.
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/moderation_set_rule/range_grade_percent.php
+++ b/classes/moderation_set_rule/range_grade_percent.php
@@ -19,7 +19,7 @@
  * moderators etc can be allocated manually or automatically.
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/moderation_set_rule/range_grade_raw.php
+++ b/classes/moderation_set_rule/range_grade_raw.php
@@ -19,7 +19,7 @@
  * moderators etc can be allocated manually or automatically.
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/moderation_set_rule/range_grade_raw.php
+++ b/classes/moderation_set_rule/range_grade_raw.php
@@ -19,7 +19,7 @@
  * moderators etc can be allocated manually or automatically.
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/moderation_set_rule/range_total_percent.php
+++ b/classes/moderation_set_rule/range_total_percent.php
@@ -19,7 +19,7 @@
  * moderators etc can be allocated manually or automatically.
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/moderation_set_rule/range_total_percent.php
+++ b/classes/moderation_set_rule/range_total_percent.php
@@ -19,7 +19,7 @@
  * moderators etc can be allocated manually or automatically.
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/observer.php
+++ b/classes/observer.php
@@ -18,7 +18,7 @@
  * Observers
  *
  * @package    mod_coursework
- * @copyright  2016 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2016 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/observer.php
+++ b/classes/observer.php
@@ -18,7 +18,7 @@
  * Observers
  *
  * @package    mod_coursework
- * @copyright  2016 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2016 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/personal_deadline/allocatable.php
+++ b/classes/personal_deadline/allocatable.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/personal_deadline/allocatable.php
+++ b/classes/personal_deadline/allocatable.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/personal_deadline/table/builder.php
+++ b/classes/personal_deadline/table/builder.php
@@ -20,7 +20,7 @@ namespace mod_coursework\personal_deadline\table;
  * Class file for the renderable object that makes the table for assigning personal deadlines to students.
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/personal_deadline/table/builder.php
+++ b/classes/personal_deadline/table/builder.php
@@ -20,7 +20,7 @@ namespace mod_coursework\personal_deadline\table;
  * Class file for the renderable object that makes the table for assigning personal deadlines to students.
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/personal_deadline/table/row/builder.php
+++ b/classes/personal_deadline/table/row/builder.php
@@ -20,7 +20,7 @@ namespace mod_coursework\personal_deadline\table\row;
  * Class file for the renderable object that makes a single row in the marker personal deadline table.
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/personal_deadline/table/row/builder.php
+++ b/classes/personal_deadline/table/row/builder.php
@@ -20,7 +20,7 @@ namespace mod_coursework\personal_deadline\table\row;
  * Class file for the renderable object that makes a single row in the marker personal deadline table.
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/plagiarism_helpers/base.php
+++ b/classes/plagiarism_helpers/base.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/plagiarism_helpers/base.php
+++ b/classes/plagiarism_helpers/base.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/plagiarism_helpers/turnitin.php
+++ b/classes/plagiarism_helpers/turnitin.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/plagiarism_helpers/turnitin.php
+++ b/classes/plagiarism_helpers/turnitin.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/base_renderer.php
+++ b/classes/render_helpers/grading_report/base_renderer.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/base_renderer.php
+++ b/classes/render_helpers/grading_report/base_renderer.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/_user_cell.php
+++ b/classes/render_helpers/grading_report/cells/_user_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/_user_cell.php
+++ b/classes/render_helpers/grading_report/cells/_user_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/allocatable_cell.php
+++ b/classes/render_helpers/grading_report/cells/allocatable_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/allocatable_cell.php
+++ b/classes/render_helpers/grading_report/cells/allocatable_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/cell_base.php
+++ b/classes/render_helpers/grading_report/cells/cell_base.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/cell_base.php
+++ b/classes/render_helpers/grading_report/cells/cell_base.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/cell_interface.php
+++ b/classes/render_helpers/grading_report/cells/cell_interface.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/cell_interface.php
+++ b/classes/render_helpers/grading_report/cells/cell_interface.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/email_cell.php
+++ b/classes/render_helpers/grading_report/cells/email_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/email_cell.php
+++ b/classes/render_helpers/grading_report/cells/email_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/first_name_cell.php
+++ b/classes/render_helpers/grading_report/cells/first_name_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/first_name_cell.php
+++ b/classes/render_helpers/grading_report/cells/first_name_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/first_name_letter_cell.php
+++ b/classes/render_helpers/grading_report/cells/first_name_letter_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/first_name_letter_cell.php
+++ b/classes/render_helpers/grading_report/cells/first_name_letter_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/grade_for_gradebook_cell.php
+++ b/classes/render_helpers/grading_report/cells/grade_for_gradebook_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/grade_for_gradebook_cell.php
+++ b/classes/render_helpers/grading_report/cells/grade_for_gradebook_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/group_cell.php
+++ b/classes/render_helpers/grading_report/cells/group_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/group_cell.php
+++ b/classes/render_helpers/grading_report/cells/group_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/idnumber_cell.php
+++ b/classes/render_helpers/grading_report/cells/idnumber_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/idnumber_cell.php
+++ b/classes/render_helpers/grading_report/cells/idnumber_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/last_name_cell.php
+++ b/classes/render_helpers/grading_report/cells/last_name_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/last_name_cell.php
+++ b/classes/render_helpers/grading_report/cells/last_name_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/last_name_letter_cell.php
+++ b/classes/render_helpers/grading_report/cells/last_name_letter_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/last_name_letter_cell.php
+++ b/classes/render_helpers/grading_report/cells/last_name_letter_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/moderation_agreement_cell.php
+++ b/classes/render_helpers/grading_report/cells/moderation_agreement_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/moderation_agreement_cell.php
+++ b/classes/render_helpers/grading_report/cells/moderation_agreement_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/moderation_cell.php
+++ b/classes/render_helpers/grading_report/cells/moderation_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/moderation_cell.php
+++ b/classes/render_helpers/grading_report/cells/moderation_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/multiple_agreed_grade_cell.php
+++ b/classes/render_helpers/grading_report/cells/multiple_agreed_grade_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/multiple_agreed_grade_cell.php
+++ b/classes/render_helpers/grading_report/cells/multiple_agreed_grade_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/personal_deadline_cell.php
+++ b/classes/render_helpers/grading_report/cells/personal_deadline_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/personal_deadline_cell.php
+++ b/classes/render_helpers/grading_report/cells/personal_deadline_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/plagiarism_cell.php
+++ b/classes/render_helpers/grading_report/cells/plagiarism_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/plagiarism_cell.php
+++ b/classes/render_helpers/grading_report/cells/plagiarism_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/plagiarism_flag_cell.php
+++ b/classes/render_helpers/grading_report/cells/plagiarism_flag_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/plagiarism_flag_cell.php
+++ b/classes/render_helpers/grading_report/cells/plagiarism_flag_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/single_assessor_feedback_cell.php
+++ b/classes/render_helpers/grading_report/cells/single_assessor_feedback_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/single_assessor_feedback_cell.php
+++ b/classes/render_helpers/grading_report/cells/single_assessor_feedback_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/status_cell.php
+++ b/classes/render_helpers/grading_report/cells/status_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/status_cell.php
+++ b/classes/render_helpers/grading_report/cells/status_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/submission_cell.php
+++ b/classes/render_helpers/grading_report/cells/submission_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/submission_cell.php
+++ b/classes/render_helpers/grading_report/cells/submission_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/time_submitted_cell.php
+++ b/classes/render_helpers/grading_report/cells/time_submitted_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/time_submitted_cell.php
+++ b/classes/render_helpers/grading_report/cells/time_submitted_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/user_cell.php
+++ b/classes/render_helpers/grading_report/cells/user_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/cells/user_cell.php
+++ b/classes/render_helpers/grading_report/cells/user_cell.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/component_factory_interface.php
+++ b/classes/render_helpers/grading_report/component_factory_interface.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/component_factory_interface.php
+++ b/classes/render_helpers/grading_report/component_factory_interface.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/multi_renderer.php
+++ b/classes/render_helpers/grading_report/multi_renderer.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/multi_renderer.php
+++ b/classes/render_helpers/grading_report/multi_renderer.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/single_renderer.php
+++ b/classes/render_helpers/grading_report/single_renderer.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/single_renderer.php
+++ b/classes/render_helpers/grading_report/single_renderer.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/sub_rows/multi_marker_feedback_sub_rows.php
+++ b/classes/render_helpers/grading_report/sub_rows/multi_marker_feedback_sub_rows.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/sub_rows/multi_marker_feedback_sub_rows.php
+++ b/classes/render_helpers/grading_report/sub_rows/multi_marker_feedback_sub_rows.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/sub_rows/no_sub_rows.php
+++ b/classes/render_helpers/grading_report/sub_rows/no_sub_rows.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/sub_rows/no_sub_rows.php
+++ b/classes/render_helpers/grading_report/sub_rows/no_sub_rows.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/sub_rows/sub_rows_interface.php
+++ b/classes/render_helpers/grading_report/sub_rows/sub_rows_interface.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/render_helpers/grading_report/sub_rows/sub_rows_interface.php
+++ b/classes/render_helpers/grading_report/sub_rows/sub_rows_interface.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/renderers/deadline_extension_renderer.php
+++ b/classes/renderers/deadline_extension_renderer.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/renderers/deadline_extension_renderer.php
+++ b/classes/renderers/deadline_extension_renderer.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/renderers/personal_deadline_renderer.php
+++ b/classes/renderers/personal_deadline_renderer.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/renderers/personal_deadline_renderer.php
+++ b/classes/renderers/personal_deadline_renderer.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/router.php
+++ b/classes/router.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/router.php
+++ b/classes/router.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/sample_set_rule/range_sample_type.php
+++ b/classes/sample_set_rule/range_sample_type.php
@@ -18,7 +18,7 @@
  * File for a sampling rule that will include X students from between an upper and lower limit.
  *
  * @package    mod_coursework
- * @copyright  2015 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2015 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/sample_set_rule/range_sample_type.php
+++ b/classes/sample_set_rule/range_sample_type.php
@@ -18,7 +18,7 @@
  * File for a sampling rule that will include X students from between an upper and lower limit.
  *
  * @package    mod_coursework
- * @copyright  2015 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2015 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/sample_set_rule/sample_base.php
+++ b/classes/sample_set_rule/sample_base.php
@@ -18,7 +18,7 @@
  * File for a sampling rule that will include X students from between an upper and lower limit.
  *
  * @package    mod_coursework
- * @copyright  2015 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2015 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/sample_set_rule/sample_base.php
+++ b/classes/sample_set_rule/sample_base.php
@@ -18,7 +18,7 @@
  * File for a sampling rule that will include X students from between an upper and lower limit.
  *
  * @package    mod_coursework
- * @copyright  2015 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2015 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/sample_set_rule/total_sample_type.php
+++ b/classes/sample_set_rule/total_sample_type.php
@@ -18,7 +18,7 @@
  * File for a sampling rule that will include X students from between an upper and lower limit.
  *
  * @package    mod_coursework
- * @copyright  2015 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2015 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/sample_set_rule/total_sample_type.php
+++ b/classes/sample_set_rule/total_sample_type.php
@@ -18,7 +18,7 @@
  * File for a sampling rule that will include X students from between an upper and lower limit.
  *
  * @package    mod_coursework
- * @copyright  2015 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2015 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/sampling_set_widget.php
+++ b/classes/sampling_set_widget.php
@@ -21,7 +21,7 @@ namespace mod_coursework;
  * etc can be allocated manually or automatically.
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/sampling_set_widget.php
+++ b/classes/sampling_set_widget.php
@@ -21,7 +21,7 @@ namespace mod_coursework;
  * etc can be allocated manually or automatically.
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/stages/assessor.php
+++ b/classes/stages/assessor.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/stages/assessor.php
+++ b/classes/stages/assessor.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/stages/base.php
+++ b/classes/stages/base.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/stages/base.php
+++ b/classes/stages/base.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/stages/final_agreed.php
+++ b/classes/stages/final_agreed.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/stages/final_agreed.php
+++ b/classes/stages/final_agreed.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/stages/moderator.php
+++ b/classes/stages/moderator.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/stages/moderator.php
+++ b/classes/stages/moderator.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/submission_files.php
+++ b/classes/submission_files.php
@@ -20,7 +20,7 @@ namespace mod_coursework;
  * Displays the information a student sees when they submit or have submitted work
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/submission_files.php
+++ b/classes/submission_files.php
@@ -20,7 +20,7 @@ namespace mod_coursework;
  * Displays the information a student sees when they submit or have submitted work
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/test_helpers/factory_mixin.php
+++ b/classes/test_helpers/factory_mixin.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/test_helpers/factory_mixin.php
+++ b/classes/test_helpers/factory_mixin.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/traits/allocatable_functions.php
+++ b/classes/traits/allocatable_functions.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/traits/allocatable_functions.php
+++ b/classes/traits/allocatable_functions.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/user_row.php
+++ b/classes/user_row.php
@@ -20,7 +20,7 @@ namespace mod_coursework;
  * Class file for the renderable object that makes a single row int he marker allocation table.
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 use mod_coursework\allocation\allocatable;

--- a/classes/user_row.php
+++ b/classes/user_row.php
@@ -20,7 +20,7 @@ namespace mod_coursework;
  * Class file for the renderable object that makes a single row int he marker allocation table.
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 use mod_coursework\allocation\allocatable;

--- a/classes/utils/cs_editor.php
+++ b/classes/utils/cs_editor.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/utils/cs_editor.php
+++ b/classes/utils/cs_editor.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/datatables/js/allocation_datatables.js
+++ b/datatables/js/allocation_datatables.js
@@ -3,7 +3,7 @@
  *
  * @package    mod
  * @subpackage coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/datatables/js/bulkplagiarismflag_datatables.js
+++ b/datatables/js/bulkplagiarismflag_datatables.js
@@ -3,7 +3,7 @@
  *
  * @package    mod
  * @subpackage coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/db/access.php
+++ b/db/access.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/db/access.php
+++ b/db/access.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/db/caches.php
+++ b/db/caches.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/db/caches.php
+++ b/db/caches.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/db/events.php
+++ b/db/events.php
@@ -18,7 +18,7 @@
  * Event handlers. Mostly for dealing with auto allocation of markers.
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/db/events.php
+++ b/db/events.php
@@ -18,7 +18,7 @@
  * Event handlers. Mostly for dealing with auto allocation of markers.
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/db/install.php
+++ b/db/install.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/db/install.php
+++ b/db/install.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/db/log.php
+++ b/db/log.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/db/log.php
+++ b/db/log.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/db/messages.php
+++ b/db/messages.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/db/messages.php
+++ b/db/messages.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -25,7 +25,7 @@
  * here will all be database-neutral, using the functions defined in DLL libraries.
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -25,7 +25,7 @@
  * here will all be database-neutral, using the functions defined in DLL libraries.
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/index.php
+++ b/index.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/index.php
+++ b/index.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/lang/en/coursework.php
+++ b/lang/en/coursework.php
@@ -18,7 +18,7 @@
  * English strings for coursework
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/lang/en/coursework.php
+++ b/lang/en/coursework.php
@@ -18,7 +18,7 @@
  * English strings for coursework
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/mod_form.php
+++ b/mod_form.php
@@ -19,7 +19,7 @@
  * instance of this module
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/mod_form.php
+++ b/mod_form.php
@@ -19,7 +19,7 @@
  * instance of this module
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/module.js
+++ b/module.js
@@ -18,7 +18,7 @@
  *
  * @package    mod
  * @subpackage coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 M.mod_coursework = {

--- a/renderable.php
+++ b/renderable.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/renderable.php
+++ b/renderable.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/renderer.php
+++ b/renderer.php
@@ -18,7 +18,7 @@
  * Renderer for the coursework module.
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/renderer.php
+++ b/renderer.php
@@ -18,7 +18,7 @@
  * Renderer for the coursework module.
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/renderers/grading_report_renderer.php
+++ b/renderers/grading_report_renderer.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/renderers/grading_report_renderer.php
+++ b/renderers/grading_report_renderer.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/renderers/object_renderer.php
+++ b/renderers/object_renderer.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/renderers/object_renderer.php
+++ b/renderers/object_renderer.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/renderers/page_renderer.php
+++ b/renderers/page_renderer.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/renderers/page_renderer.php
+++ b/renderers/page_renderer.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/settings.php
+++ b/settings.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/settings.php
+++ b/settings.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/behat/pages/allocations_page.php
+++ b/tests/behat/pages/allocations_page.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/behat/pages/allocations_page.php
+++ b/tests/behat/pages/allocations_page.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/behat/pages/coursework_page.php
+++ b/tests/behat/pages/coursework_page.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/behat/pages/coursework_page.php
+++ b/tests/behat/pages/coursework_page.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/behat/pages/edit_extension_page.php
+++ b/tests/behat/pages/edit_extension_page.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/behat/pages/edit_extension_page.php
+++ b/tests/behat/pages/edit_extension_page.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/behat/pages/gradebook_page.php
+++ b/tests/behat/pages/gradebook_page.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/behat/pages/gradebook_page.php
+++ b/tests/behat/pages/gradebook_page.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/behat/pages/login_page.php
+++ b/tests/behat/pages/login_page.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/behat/pages/login_page.php
+++ b/tests/behat/pages/login_page.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/behat/pages/multiple_grading_interface.php
+++ b/tests/behat/pages/multiple_grading_interface.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/behat/pages/multiple_grading_interface.php
+++ b/tests/behat/pages/multiple_grading_interface.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/behat/pages/new_extension_page.php
+++ b/tests/behat/pages/new_extension_page.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/behat/pages/new_extension_page.php
+++ b/tests/behat/pages/new_extension_page.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/behat/pages/page_base.php
+++ b/tests/behat/pages/page_base.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/behat/pages/page_base.php
+++ b/tests/behat/pages/page_base.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/behat/pages/show_feedback_page.php
+++ b/tests/behat/pages/show_feedback_page.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/behat/pages/show_feedback_page.php
+++ b/tests/behat/pages/show_feedback_page.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/behat/pages/single_grading_interface.php
+++ b/tests/behat/pages/single_grading_interface.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/behat/pages/single_grading_interface.php
+++ b/tests/behat/pages/single_grading_interface.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/behat/pages/student_page.php
+++ b/tests/behat/pages/student_page.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/behat/pages/student_page.php
+++ b/tests/behat/pages/student_page.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/behat/pages/student_submission_form.php
+++ b/tests/behat/pages/student_submission_form.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/behat/pages/student_submission_form.php
+++ b/tests/behat/pages/student_submission_form.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/ability_test.php
+++ b/tests/classes/ability_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/ability_test.php
+++ b/tests/classes/ability_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/allocation/auto_allocator_test.php
+++ b/tests/classes/allocation/auto_allocator_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/allocation/auto_allocator_test.php
+++ b/tests/classes/allocation/auto_allocator_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/allocation/form/table_processor_test.php
+++ b/tests/classes/allocation/form/table_processor_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/allocation/form/table_processor_test.php
+++ b/tests/classes/allocation/form/table_processor_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/allocation/strategy/percentages_test.php
+++ b/tests/classes/allocation/strategy/percentages_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/allocation/strategy/percentages_test.php
+++ b/tests/classes/allocation/strategy/percentages_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/allocation/strategy_test.php
+++ b/tests/classes/allocation/strategy_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/allocation/strategy_test.php
+++ b/tests/classes/allocation/strategy_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/auto_grader/percentage_distance_test.php
+++ b/tests/classes/auto_grader/percentage_distance_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/auto_grader/percentage_distance_test.php
+++ b/tests/classes/auto_grader/percentage_distance_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/controllers/deadline_extensions_controller_test.php
+++ b/tests/classes/controllers/deadline_extensions_controller_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/controllers/deadline_extensions_controller_test.php
+++ b/tests/classes/controllers/deadline_extensions_controller_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/cron_test.php
+++ b/tests/classes/cron_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/cron_test.php
+++ b/tests/classes/cron_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/export/csv_test.php
+++ b/tests/classes/export/csv_test.php
@@ -18,7 +18,7 @@
  * Unit tests for the csv class
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/export/csv_test.php
+++ b/tests/classes/export/csv_test.php
@@ -18,7 +18,7 @@
  * Unit tests for the csv class
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/grade_judge_test.php
+++ b/tests/classes/grade_judge_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/grade_judge_test.php
+++ b/tests/classes/grade_judge_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/models/coursework_test.php
+++ b/tests/classes/models/coursework_test.php
@@ -18,7 +18,7 @@
  * Unit tests for the coursework class
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/models/coursework_test.php
+++ b/tests/classes/models/coursework_test.php
@@ -18,7 +18,7 @@
  * Unit tests for the coursework class
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/models/deadline_extension_test.php
+++ b/tests/classes/models/deadline_extension_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/models/deadline_extension_test.php
+++ b/tests/classes/models/deadline_extension_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/models/group_test.php
+++ b/tests/classes/models/group_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/models/group_test.php
+++ b/tests/classes/models/group_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/models/moderation_set_membership_test.php
+++ b/tests/classes/models/moderation_set_membership_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/models/moderation_set_membership_test.php
+++ b/tests/classes/models/moderation_set_membership_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/models/submission_test.php
+++ b/tests/classes/models/submission_test.php
@@ -18,7 +18,7 @@
  * Unit tests for the coursework class
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/models/submission_test.php
+++ b/tests/classes/models/submission_test.php
@@ -18,7 +18,7 @@
  * Unit tests for the coursework class
  *
  * @package    mod_coursework
- * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/models/user_test.php
+++ b/tests/classes/models/user_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/models/user_test.php
+++ b/tests/classes/models/user_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/router_test.php
+++ b/tests/classes/router_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/router_test.php
+++ b/tests/classes/router_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/rule_test.php
+++ b/tests/classes/rule_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/rule_test.php
+++ b/tests/classes/rule_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/stages/assessor_test.php
+++ b/tests/classes/stages/assessor_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/stages/assessor_test.php
+++ b/tests/classes/stages/assessor_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/stages/final_agreed_test.php
+++ b/tests/classes/stages/final_agreed_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/classes/stages/final_agreed_test.php
+++ b/tests/classes/stages/final_agreed_test.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/cron_tester.php
+++ b/tests/cron_tester.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/cron_tester.php
+++ b/tests/cron_tester.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2017 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2017 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -19,7 +19,7 @@
  *
  * @package    mod_coursework
  * @category   phpunit
- * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -19,7 +19,7 @@
  *
  * @package    mod_coursework
  * @category   phpunit
- * @copyright  2012 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2012 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/generator_test.php
+++ b/tests/generator_test.php
@@ -19,7 +19,7 @@
  *
  * @package    mod_coursework
  * @category   phpunit
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
@@ -36,7 +36,7 @@ require_once($CFG->dirroot . '/mod/coursework/lib.php');
  *
  * @package    mod_coursework
  * @category   phpunit
- * @copyright  2012 ULCC {@link http://ulcc.ac.uk}
+ * @copyright  2012 ULCC {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 final class generator_test extends \advanced_testcase {

--- a/tests/generator_test.php
+++ b/tests/generator_test.php
@@ -19,7 +19,7 @@
  *
  * @package    mod_coursework
  * @category   phpunit
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/renderer_test.php
+++ b/tests/renderer_test.php
@@ -17,7 +17,7 @@
 /**
  *
  * @package   mod_coursework
- * @copyright  2012 ULCC {@link http://ulcc.ac.uk}
+ * @copyright  2012 ULCC {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/version.php
+++ b/version.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/version.php
+++ b/version.php
@@ -16,7 +16,7 @@
 
 /**
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/view.php
+++ b/view.php
@@ -18,7 +18,7 @@
  * Prints a particular instance of coursework
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/view.php
+++ b/view.php
@@ -18,7 +18,7 @@
  * Prints a particular instance of coursework
  *
  * @package    mod_coursework
- * @copyright  2011 University of London Computer Centre {@link http://ulcc.ac.uk}
+ * @copyright  2011 University of London Computer Centre {@link https://www.cosector.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 


### PR DESCRIPTION
This is a simple search and replace of {@link ulcc.ac.uk} for {@link http://ulcc.ac.uk} as it's causing lots of warnings on the PHPDocs CI check