### PR TITLE
Fix bug when no submissions notifiers are selected

### DIFF
--- a/classes/controllers/submissions_controller.php
+++ b/classes/controllers/submissions_controller.php
@@ -170,9 +170,10 @@ class submissions_controller extends controller_base {
         if ($submission->finalised) {
             if (!$submission->get_coursework()->has_deadline()) {
 
-                $userids = explode(',', $submission->get_coursework()->get_submission_notification_users());
+                $useridcommaseparatedlist = $submission->get_coursework()->get_submission_notification_users();
 
-                if (!empty($userids)) {
+                if (!empty($useridcommaseparatedlist)) {
+                    $userids = explode(',', $useridcommaseparatedlist);
                     foreach ($userids as $u) {
                         $notifyuser = $DB->get_record('user', ['id' => trim($u)]);
 

--- a/classes/forms/student_submission_form.php
+++ b/classes/forms/student_submission_form.php
@@ -175,9 +175,10 @@ class student_submission_form extends moodleform {
 
                     if (!$submission->get_coursework()->has_deadline()) {
 
-                        $userids = explode(',', $submission->get_coursework()->get_submission_notification_users());
+                        $useridcommaseparatedlist = $submission->get_coursework()->get_submission_notification_users();
 
-                        if (!empty($userids)) {
+                        if (!empty($useridcommaseparatedlist)) {
+                            $userids = explode(',', $useridcommaseparatedlist);
                             foreach ($userids as $u) {
                                 $notifyuser = $DB->get_record('user', ['id' => trim($u)]);
                                 $mailer = new mailer($coursework);


### PR DESCRIPTION
In Moodle 4.1, I encountered this error situation:

1. Create a coursework activity
2. Give it no deadline
3. Assign no users to be notified upon submission
4. Upload a file for the assignment

Expected result: works fine

Actual result: The submission gets uploaded, but the page displays an error message "ERROR invalid input syntax for type bigint: "" SELECT * FROM mdl_user WHERE id=$1 [array (0 => '',)]", coming from line 158 of mod/coursework/classes/controllers/submissions_controller.php

Ultimately it looks like the problem is that the notifiers are stored in the DB as a string containing a comma-separated list of user ids. The code that's meant to send submission notifications pulls this string and parses it with `explode()`. Before doing anything it, then checks if the result is `empty()`.

But when there are no users subscribed, then the list of user ids is instead an empty string `''`. Doing `explode('')` gives an array containing a single empty string `['']`, and that is not `empty()`. That then results in an attempt to use the empty string as an integer in a SQL query, causing the error.

This patch fixes the issue by doing the `empty()` check on the string containing the user ids, _before_ parsing it with `explode()`.