### PR TITLE
CTP-4147 Fix calendar PHPUnit test

### DIFF
--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -107,8 +107,10 @@ class mod_coursework_generator extends testing_module_generator {
             $record->moderatorallocationstrategy = 'none';
         }
 
-        return coursework::find(parent::create_instance($record, $options)->id);
-
+        $module = parent::create_instance($record, $options);
+        $coursework = coursework::find($module->id);
+        $coursework->cmid = $module->cmid;
+        return $coursework;
     }
 
     /**


### PR DESCRIPTION
Populate $cmid in mod_coursework_generator->create_instance() as this is needed by core PHPUnit tests, for example, when calling course_delete_module().  Previously core test
core_calendar\container_test::test_delete_module_delete_events failed because $cmid was missing.