### PR TITLE
CTP-4147 Fix calendar PHPUnit test

### DIFF
--- a/classes/test_helpers/factory_mixin.php
+++ b/classes/test_helpers/factory_mixin.php
@@ -203,12 +203,14 @@ trait factory_mixin {
     /**
      * Makes a coursework and saves it as $this->coursework
      *
-     * @throws coding_exception
+     * @param array $params
      * @return coursework
      */
-    protected function create_a_coursework() {
+    protected function create_a_coursework(array $params = []) {
         $generator = $this->get_coursework_generator();
-        $this->coursework = $generator->create_instance(['course' => $this->get_course()->id]);
+        $params['course'] = $this->get_course()->id;
+        $module = $generator->create_instance($params);
+        $this->coursework = coursework::find($module->id);
         return $this->coursework;
     }
 

--- a/tests/behat/behat_mod_coursework.php
+++ b/tests/behat/behat_mod_coursework.php
@@ -1526,7 +1526,7 @@ class behat_mod_coursework extends behat_base {
 
         $coursework = new stdClass();
         $coursework->course = $this->course;
-        $this->coursework = $generator->create_instance($coursework);
+        $this->coursework = coursework::find($generator->create_instance($coursework)->id);
     }
 
     /**

--- a/tests/classes/allocation/auto_allocator_test.php
+++ b/tests/classes/allocation/auto_allocator_test.php
@@ -40,20 +40,16 @@ final class auto_allocator_test extends advanced_testcase {
         $this->setAdminUser();
 
         $generator = $this->getDataGenerator();
-        /**
-         * @var mod_coursework_generator $coursework_generator
-         */
-        $courseworkgenerator = $generator->get_plugin_generator('mod_coursework');
 
         $this->course = $generator->create_course();
 
-        $coursework = new stdClass();
-        $coursework->course = $this->course;
-        $coursework->moderationenabled = 1;
-        $coursework->allocationenabled = 1;
-        $coursework->assessorallocationstrategy = 'equal';
-        $coursework->moderatorallocationstrategy = 'equal';
-        $this->coursework = $courseworkgenerator->create_instance($coursework);
+        $params = [
+            'moderationenabled' => 1,
+            'allocationenabled' => 1,
+            'assessorallocationstrategy' => 'equal',
+            'moderatorallocationstrategy' => 'equal',
+        ];
+        $this->coursework = $this->create_a_coursework($params);
 
         $this->create_a_student();
         $this->create_a_teacher();

--- a/tests/classes/allocation/form/table_processor_test.php
+++ b/tests/classes/allocation/form/table_processor_test.php
@@ -47,14 +47,7 @@ final class table_processor_test extends advanced_testcase {
         $this->resetAfterTest();
         $this->setAdminUser();
 
-        $generator = $this->getDataGenerator();
-        $courseworkgenerator = $generator->get_plugin_generator('mod_coursework');
-
-        $this->course = $generator->create_course();
-        $coursework = new stdClass();
-        $coursework->course = $this->course;
-        $coursework->numberofmarkers = 2;
-        $this->coursework = $courseworkgenerator->create_instance($coursework);
+        $this->coursework = $this->create_a_coursework(['numberofmarkers' => 2]);
 
         $this->create_a_student();
         $this->create_a_teacher();

--- a/tests/classes/export/csv_test.php
+++ b/tests/classes/export/csv_test.php
@@ -57,15 +57,13 @@ final class csv_test extends advanced_testcase {
         $dateformat = '%a, %d %b %Y, %H:%M';
         $generator = $this->getDataGenerator()->get_plugin_generator('mod_coursework');
 
-        $coursework = $generator->create_instance(
-            [
-                'course' => $this->course->id,
-                'grade' => 100,
-                'numberofmarkers' => 1,
-                'deadline' => time() + 86400,
-                'extensionsenabled' => 1,
-            ]
-        );
+        $params = [
+            'grade' => 100,
+            'numberofmarkers' => 1,
+            'deadline' => time() + 86400,
+            'extensionsenabled' => 1,
+        ];
+        $coursework = $this->create_a_coursework($params);
         $submission = new stdClass();
         $submission->userid = $this->student->id;
         $submission->allocatableid = $this->student->id;
@@ -152,14 +150,12 @@ final class csv_test extends advanced_testcase {
         $dateformat = '%a, %d %b %Y, %H:%M';
         $generator = $this->getDataGenerator()->get_plugin_generator('mod_coursework');
 
-        $coursework = $generator->create_instance(
-            [
-                'course' => $this->course->id,
-                'grade' => 100,
-                'numberofmarkers' => 2,
-                'deadline' => strtotime('-1 day', $timenow), // This means that the submissions will be late.
-            ]
-        );
+        $params = [
+            'grade' => 100,
+            'numberofmarkers' => 2,
+            'deadline' => strtotime('-1 day', $timenow), // This means that the submissions will be late.
+        ];
+        $coursework = $this->create_a_coursework($params);
 
         $submission = new stdClass();
         $submission->userid = $this->student->id;
@@ -251,15 +247,13 @@ final class csv_test extends advanced_testcase {
         $dateformat = '%a, %d %b %Y, %H:%M';
         $generator = $this->getDataGenerator()->get_plugin_generator('mod_coursework');
 
-        $coursework = $generator->create_instance(
-            [
-                'course' => $this->course->id,
-                'grade' => 100,
-                'numberofmarkers' => 2,
-                'samplingenabled' => 1,
-                'deadline' => time() + 86400,
-            ]
-        );
+        $params = [
+            'grade' => 100,
+            'numberofmarkers' => 2,
+            'samplingenabled' => 1,
+            'deadline' => time() + 86400,
+        ];
+        $coursework = $this->create_a_coursework($params);
         $submission = new stdClass();
         $submission->userid = $this->student->id;
         $submission = $generator->create_submission($submission, $coursework);
@@ -330,15 +324,13 @@ final class csv_test extends advanced_testcase {
         $dateformat = '%a, %d %b %Y, %H:%M';
         $generator = $this->getDataGenerator()->get_plugin_generator('mod_coursework');
 
-        $coursework = $generator->create_instance(
-            [
-                'course' => $this->course->id,
-                'grade' => 100,
-                'numberofmarkers' => 2,
-                'samplingenabled' => 1,
-                'deadline' => time() + 86400,
-            ]
-        );
+        $params = [
+            'grade' => 100,
+            'numberofmarkers' => 2,
+            'samplingenabled' => 1,
+            'deadline' => time() + 86400,
+        ];
+        $coursework = $this->create_a_coursework($params);
         $student1 = $this->student;
         $assessor1 = $this->teacher;
         $assessor2 = $this->otherteacher;

--- a/tests/classes/export/grading_sheet_download_test.php
+++ b/tests/classes/export/grading_sheet_download_test.php
@@ -59,10 +59,12 @@ final class grading_sheet_download_test extends advanced_testcase {
     public function test_one_stage_no_allocations(): void {
 
         $generator = $this->getDataGenerator()->get_plugin_generator('mod_coursework');
-        $coursework = $generator->create_instance(['course' => $this->course->id,
-                                                             'grade' => 100,
-                                                             'numberofmarkers' => 1,
-                                                             'deadline' => time() + 86400]);
+        $params = [
+             'grade' => 100,
+             'numberofmarkers' => 1,
+             'deadline' => time() + 86400,
+        ];
+        $coursework = $this->create_a_coursework($params);
         $submission = new stdClass();
         $submission->userid = $this->student->id;
         $submission->allocatableid = $this->student->id;
@@ -101,16 +103,13 @@ final class grading_sheet_download_test extends advanced_testcase {
      */
     public function test_two_stages_with_allocations(): void {
         $generator = $this->getDataGenerator()->get_plugin_generator('mod_coursework');
-
-        $coursework = $generator->create_instance(
-            [
-                'course' => $this->course->id,
-                'grade' => 100,
-                'numberofmarkers' => 2,
-                'allocationenabled' => 1,
-                'deadline' => time() + 86400,
-            ]
-        );
+        $params = [
+            'grade' => 100,
+            'numberofmarkers' => 2,
+            'allocationenabled' => 1,
+            'deadline' => time() + 86400,
+        ];
+        $coursework = $this->create_a_coursework($params);
 
         // 2 assessors
         $assessor1 = $this->teacher;

--- a/tests/classes/models/coursework_test.php
+++ b/tests/classes/models/coursework_test.php
@@ -48,9 +48,8 @@ final class coursework_test extends advanced_testcase {
     public function setUp(): void {
         $this->resetAfterTest();
         $this->course = $this->getDataGenerator()->create_course();
-        $generator = $this->getDataGenerator()->get_plugin_generator('mod_coursework');
         $this->setAdminUser();
-        $this->coursework = $generator->create_instance(['course' => $this->course->id, 'grade' => 0]);
+        $this->coursework = $this->create_a_coursework(['grade' => 0]);
     }
 
     /**
@@ -91,8 +90,7 @@ final class coursework_test extends advanced_testcase {
         $this->assertInstanceOf('\mod_coursework\allocation\manager', $allocationmanager);
 
         // Now make a new coursework with a duff class name.
-        $generator = $this->getDataGenerator()->get_plugin_generator('mod_coursework');
-        $this->coursework = $generator->create_instance(['course' => $this->course->id, 'grade' => 0]);
+        $this->coursework = $this->create_a_coursework(['grade' => 0]);
         $this->coursework->assessorallocationstrategy = 'duffclass';
         $this->coursework->save();
 
@@ -101,67 +99,61 @@ final class coursework_test extends advanced_testcase {
     }
 
     public function test_group_decorator_is_added(): void {
-        $generator = $this->getDataGenerator()->get_plugin_generator('mod_coursework');
-        $coursework = $generator->create_instance(['course' => $this->course->id,
-                                                        'grade' => 0,
-                                                        'use_groups' => true]);
+        $params = [
+            'grade' => 0,
+            'use_groups' => true,
+        ];
+        $coursework = $this->create_a_coursework($params);
         $this->assertInstanceOf('\mod_coursework\decorators\coursework_groups_decorator', coursework::find($coursework->id));
     }
 
     public function test_group_decorator_is_not_added(): void {
-        $generator = $this->getDataGenerator()->get_plugin_generator('mod_coursework');
-        $coursework = $generator->create_instance(['course' => $this->course->id,
-                                                        'grade' => 0]);
+        $coursework = $this->create_a_coursework(['grade' => 0]);
         $this->assertInstanceOf('\mod_coursework\models\coursework',
                                 coursework::find($coursework->id));
     }
 
     public function test_get_user_group_no_grouping(): void {
-
-        $generator = $this->get_coursework_generator();
-
         $this->create_a_student();
         $this->create_a_group();
         $this->add_student_to_the_group();
 
-        $coursework = $generator->create_instance(['course' => $this->course->id,
-                                                        'grade' => 0,
-                                                        'use_groups' => true]);
-
+        $params = [
+            'grade' => 0,
+            'use_groups' => true,
+        ];
+        $coursework = $this->create_a_coursework($params);
         $this->assertEquals($this->group->id, $coursework->get_student_group($this->student)->id);
 
     }
 
     public function test_get_user_group_with_grouping(): void {
-
-        $generator = $this->get_coursework_generator();
-
         $this->create_a_student();
         $this->create_a_group();
         $this->create_a_grouping_and_add_the_group_to_it();
         $this->add_student_to_the_group();
 
-        $coursework = $generator->create_instance(['course' => $this->course->id,
-                                                        'grade' => 0,
-                                                        'use_groups' => true,
-                                                        'grouping_id' => $this->grouping->id]);
-
+        $params = [
+            'grade' => 0,
+            'use_groups' => true,
+            'grouping_id' => $this->grouping->id,
+        ];
+        $coursework = $this->create_a_coursework($params);
         $this->assertEquals($this->group->id, $coursework->get_student_group($this->student)->id);
     }
 
     public function test_get_user_group_with_wrong_grouping(): void {
-        $generator = $this->get_coursework_generator();
-
         $this->create_a_student();
         $this->create_a_group();
         $this->create_a_grouping_and_add_the_group_to_it();
         $this->add_student_to_the_group();
 
-        $coursework = $generator->create_instance(['course' => $this->course->id,
-                                                        'grade' => 0,
-                                                        'use_groups' => true,
-                                                        'grouping_id' => 543]);
-
+        $params = [
+            'grade' => 0,
+            'use_groups' => true,
+            'grouping_id' => 543,
+        ];
+        $coursework = $this->create_a_coursework($params);
         $this->assertFalse($coursework->get_student_group($this->student));
     }
 

--- a/tests/classes/models/submission_test.php
+++ b/tests/classes/models/submission_test.php
@@ -43,9 +43,8 @@ final class coursework_submission_test extends advanced_testcase {
         $this->resetAfterTest();
 
         $this->course = $this->getDataGenerator()->create_course();
-        $generator = $this->getDataGenerator()->get_plugin_generator('mod_coursework');
         $this->setAdminUser();
-        $this->coursework = $generator->create_instance(['course' => $this->course->id, 'grade' => 0]);
+        $this->coursework = $this->create_a_coursework(['grade' => 0]);
         $this->redirectMessages();
         $this->preventResetByRollback();
 
@@ -101,8 +100,7 @@ final class coursework_submission_test extends advanced_testcase {
 
     public function test_group_decorator_is_not_added(): void {
         $generator = $this->getDataGenerator()->get_plugin_generator('mod_coursework');
-        $coursework = $generator->create_instance(['course' => $this->course->id,
-                                                        'grade' => 0]);
+        $coursework = $this->create_a_coursework(['grade' => 0]);
 
         $submission = new stdClass();
         $submission->userid = 2;

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -107,8 +107,7 @@ class mod_coursework_generator extends testing_module_generator {
             $record->moderatorallocationstrategy = 'none';
         }
 
-        return coursework::find(parent::create_instance($record, $options)->id);
-
+        return parent::create_instance($record, $options);
     }
 
     /**

--- a/tests/generator_test.php
+++ b/tests/generator_test.php
@@ -25,6 +25,8 @@
 
 namespace mod_coursework;
 
+use mod_coursework\models\coursework;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
@@ -83,7 +85,7 @@ final class generator_test extends \advanced_testcase {
         $this->assertEquals($course->id, $cm->course);
 
         $context = \context_module::instance($cm->id);
-        $this->assertEquals($coursework->get_coursemodule_id(), $context->instanceid);
+        $this->assertEquals(coursework::find($coursework)->get_coursemodule_id(), $context->instanceid);
 
         // Test gradebook integration using low level DB access - DO NOT USE IN PLUGIN CODE!
         $gitem = $DB->get_record('grade_items',
@@ -183,7 +185,7 @@ final class generator_test extends \advanced_testcase {
         $data->userid = $user->id;
 
         // Should fail because we have no assessorid and we have no logged ourselves in.
-        $submission = $generator->create_submission($data, $coursework);
+        $submission = $generator->create_submission($data, coursework::find($coursework));
         $submission = $DB->get_record('coursework_submissions', ['id' => $submission->id]);
 
         $this->assertNotEmpty($submission);


### PR DESCRIPTION
Rework mod_coursework_generator->create_instance() and mod_coursework\test_helpers\factory_mixin->create_a_coursework() so that the former returns a stdClass with a populated cmid property for use with core Moodle PHPUnit tests, and the latter returns a mod_coursework\models\coursework instance where cmid is null.  PHPUnit tests which depend on the latter but previously called create_instance() have been updated to call create_a_coursework().

This fixes
core_calendar\container_test::test_delete_module_delete_events which previously failed with "Failed asserting that an object is empty".