### PR TITLE
CTP-4110 Fix finalise submissions after deadline

### DIFF
--- a/classes/models/coursework.php
+++ b/classes/models/coursework.php
@@ -2463,6 +2463,7 @@ class coursework extends table_base {
         $DB->execute("UPDATE {coursework_submissions}
                          SET finalised = 1
                        WHERE courseworkid = ? $excludesql", [$this->id]);
+        \mod_coursework\models\submission::remove_cache($this->id);
     }
 
     /**

--- a/tests/behat/submissions_auto_finalisation.feature
+++ b/tests/behat/submissions_auto_finalisation.feature
@@ -14,8 +14,9 @@ Feature: Auto finalising before cron runs
 
   Scenario: Teacher visits the page and sees the submission is finalised when the deadline has passed
     Given I am logged in as a teacher
+    And I visit the coursework page
     And the coursework deadline has passed
-    When I visit the coursework page
+    When I reload the page
     Then I should see "Ready to grade"
 
   Scenario: Teacher visits the page and sees the submission is not finalised when the deadline has not passed


### PR DESCRIPTION
When the coursework deadline has passed submissions are finalised in the database, however the previous cached value was shown to teachers. We now clear this cache after updating the database.

Behat test submissions_auto_finalisation.feature has been updated to additionally test for this by viewing view.php before the deadline has passed to populate the cache, then reloading after finalising submissions, checking for the expected status.