### PR TITLE
CTP-4103 Fix Per page selector doesn't apply

### DIFF
--- a/actions/allocate.php
+++ b/actions/allocate.php
@@ -205,11 +205,6 @@ if ($coursework->sampling_enabled()) { // Do not delete yet - refactoring...
     echo html_writer::end_tag('form');
 }
 
-// Start form. The page has now been broken into two forms sampling section and allocation section
-// Open form tag.
-echo \html_writer::start_tag('form', ['id' => 'allocation_form',
-    'method' => 'post']);
-
 if ($coursework->allocation_enabled()) {
     echo $objectrenderer->render($allocationwidget);
 }
@@ -234,7 +229,5 @@ echo html_writer::empty_tag('input', $attributes);
 echo $OUTPUT->help_icon('savemanualallocations', 'mod_coursework');
 */
 echo $objectrenderer->render($allocationtable);
-
-echo html_writer::end_tag('form');
 
 echo $OUTPUT->footer();

--- a/renderers/object_renderer.php
+++ b/renderers/object_renderer.php
@@ -561,21 +561,10 @@ class mod_coursework_object_renderer extends plugin_renderer_base {
         global $SESSION;
 
         $tablehtml = $allocationtable->get_hidden_elements();
-
-        $tablehtml .= '
-
-            <table class="allocations display">
-                <thead>
-                <tr>
-
-        ';
-
+        $all = count($allocationtable->get_coursework()->get_allocatables());
         $options = $allocationtable->get_options();
 
-        $pagingbar = new paging_bar($allocationtable->get_participant_count(), $options['page'], $options['perpage'],
-            $this->page->url, 'page');
-
-        $all = count($allocationtable->get_coursework()->get_allocatables());
+        $tablehtml .= '<div class="table-and-jumptos">';
 
         $recordsperpage = [3 => 3,
             10 => 10,
@@ -592,8 +581,20 @@ class mod_coursework_object_renderer extends plugin_renderer_base {
         $select = new single_select($this->page->url, 'per_page', $recordsperpage, $options['perpage'], null);
         $select->label = get_string('records_per_page', 'coursework');
         $select->class = 'jumpmenu';
-        $select->formid = 'sectionmenu';
+        $select->formid = 'sectionmenutop';
         $tablehtml .= $this->output->render($select);
+        $tablehtml .= \html_writer::start_tag('form', ['method' => 'post']);
+
+        $tablehtml .= '
+
+            <table class="allocations display">
+                <thead>
+                <tr>
+
+        ';
+
+        $pagingbar = new paging_bar($allocationtable->get_participant_count(), $options['page'], $options['perpage'],
+            $this->page->url, 'page');
 
         // Get the hidden elements used for assessors and moderators selected on other pages;
 
@@ -650,8 +651,11 @@ class mod_coursework_object_renderer extends plugin_renderer_base {
             'id' => 'save_manual_allocations_1',
             'value' => get_string('save', 'mod_coursework')];
         $tablehtml .= html_writer::empty_tag('input', $attributes);
+        $tablehtml .= html_writer::end_tag('form');
 
+        $select->formid = 'sectionmenubottom';
         $tablehtml .= $this->output->render($select);
+        $tablehtml .= '</div>';
 
         $tablehtml .= $this->page->get_renderer('mod_coursework', 'object')->render($pagingbar);
 
@@ -703,7 +707,9 @@ class mod_coursework_object_renderer extends plugin_renderer_base {
         // $html .= $this->output->help_icon('allocationstrategy', 'mod_coursework');
         $html .= html_writer::end_tag('h3');
 
-        $html .= '<div class="allocation-strategy"';
+        $html .= '<div class="allocation-strategy">';
+        $html .= \html_writer::start_tag('form',
+            ['id' => 'allocation_form', 'method' => 'post']);
         // Allow allocation method to be changed.
         $html .= html_writer::label(get_string('allocationstrategy', 'mod_coursework'), 'assessorallocationstrategy');
 
@@ -740,6 +746,7 @@ class mod_coursework_object_renderer extends plugin_renderer_base {
             'value' => get_string('save_and_exit', 'mod_coursework')];
         $html .= html_writer::empty_tag('input', $attributes);
         $html .= html_writer::end_tag('div');
+        $html .= html_writer::end_tag('form');
         $html .= '</div>';
         $html .= '</div>';
 

--- a/styles.css
+++ b/styles.css
@@ -1086,3 +1086,15 @@ div.dtsp-searchPanes div.dataTables_scrollBody tbody tr.selected td {
 .feedbacknotestoggle.expanded {
     background: url([[pix:coursework|details_close]]) no-repeat;
 }
+
+/* Container to help position lower "Showing:" jumpto */
+body#page-mod-coursework-actions-allocate div.table-and-jumptos {
+    position: relative;
+}
+
+/* Vertically align lower "Showing:" jumpto with the "Save" button */
+body#page-mod-coursework-actions-allocate div.table-and-jumptos form + div.jumpmenu {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+}


### PR DESCRIPTION
Previously the top "Showing:" dropdown list on the allocate assessors page didn't work (the lower one did work).  To resolve this these two dropdowns have been moved outside the main <form>.  To keep the lower dropdown vertically aligned with the "Save" button a containing <div> has been added to position this element with CSS.