### PR TITLE
CTP-4041 Combine feedback if automatically agreed

### DIFF
--- a/classes/traits/autoagreement_functions.php
+++ b/classes/traits/autoagreement_functions.php
@@ -1,0 +1,54 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * @package    mod_coursework
+ * @copyright  2025 onwards University College London {@link https://www.ucl.ac.uk/}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_coursework\traits;
+
+/**
+ * Functions for the auto agreement strategies.
+ * @package mod_coursework\traits
+ */
+trait autoagreement_functions {
+    /**
+     * Combine the markers' feedback comments into a single comment for the
+     * agreed feedback.
+     */
+    public function feedback_comments() {
+        global $DB;
+
+        $feedbacks = $DB->get_records('coursework_feedbacks', [
+            'submissionid' => $this->get_allocatable()->get_submission($this->get_coursework())->id(),
+            'isfinalgrade' => 0,
+        ]);
+        $feedbackcomment = '';
+        $count = 1;
+
+        foreach ($feedbacks as $feedback) {
+            // Put all initial feedbacks together for the comment field.
+            $feedbackcomment .= get_string('assessorcomments', 'mod_coursework', $count);
+            $feedbackcomment .= $feedback->feedbackcomment;
+            $feedbackcomment .= '<br>';
+            $count++;
+        }
+
+        return $feedbackcomment;
+    }
+}

--- a/tests/behat/automatic_agreement.feature
+++ b/tests/behat/automatic_agreement.feature
@@ -44,3 +44,15 @@ Feature: Automatic agreement for simple grades
     When I grade the submission as 63 using the ajax form
     And I visit the coursework page
     Then I should see the final grade as 67 on the multiple marker page
+
+  @javascript
+  Scenario: If "Auto-populate agreed feedback comment" is enabled then the final grade should contain the combined feedback of markers
+    Given the coursework "automaticagreementstrategy" setting is "percentage_distance" in the database
+    Given the coursework "automaticagreementrange" setting is "10" in the database
+    Given the coursework "autopopulatefeedbackcomment" setting is "1" in the database
+    Given there are feedbacks from both teachers
+    And I am logged in as a manager
+    And I visit the coursework page
+    When I click the edit final feedback button
+    And I wait until the page is ready
+    Then the grade comment textarea field matches "Assessor 1 comment:New comment hereAssessor 2 comment:New comment here"

--- a/tests/behat/behat_mod_coursework.php
+++ b/tests/behat/behat_mod_coursework.php
@@ -2178,7 +2178,6 @@ class behat_mod_coursework extends behat_base {
         $feedback = new stdClass();
         $feedback->assessorid = $this->teacher->id;
         $feedback->submissionid = $this->submission->id;
-        $feedback->feedbackcomment = 'New comment here';
         $feedback->stage_identifier = 'assessor_1';
         $feedback->feedbackcomment = 'New comment here';
         $feedback->grade = 67;


### PR DESCRIPTION
When "Automatic agreement of grades" is "percentage distance" or "average grade", and "Auto-populate agreed feedback comment" is enabled, combine the feedback comments from all markers when the final grade is automatically populated.