### PR TITLE
CTP-4501 Add support for decimal points

### DIFF
--- a/classes/auto_grader/average_grade.php
+++ b/classes/auto_grader/average_grade.php
@@ -110,7 +110,7 @@ class average_grade implements auto_grader {
         // round it according to the chosen rule
         switch ($this->roundingrule) {
             case 'mid':
-                $avggrade = round($avggrade);
+                $avggrade = round($avggrade, $this->coursework->get_grade_item()->get_decimals());
                 break;
             case 'up':
                 $avggrade = ceil($avggrade);

--- a/classes/controllers/feedback_controller.php
+++ b/classes/controllers/feedback_controller.php
@@ -164,6 +164,7 @@ class feedback_controller extends controller_base {
             $editor = $assessor;
         }
 
+        $teacherfeedback->grade = format_float($teacherfeedback->grade, $this->coursework->get_grade_item()->get_decimals());
         $renderer = $this->get_page_renderer();
         $renderer->edit_feedback_page($teacherfeedback, $assessor, $editor, $this->params['ajax']);
     }

--- a/classes/forms/assessor_feedback_mform.php
+++ b/classes/forms/assessor_feedback_mform.php
@@ -92,6 +92,9 @@ class assessor_feedback_mform extends moodleform {
             $this->_grading_controller = $coursework->get_advanced_grading_active_controller();
             $this->_grading_instance = $this->_grading_controller->get_or_create_instance(0, $feedback->assessorid, $feedback->id);
             $mform->addElement('grading', 'advancedgrading', get_string('grade', 'mod_coursework'), ['gradinginstance' => $this->_grading_instance]);
+        } else if ($feedback->stage_identifier == 'final_agreed_1') {
+            $mform->addElement('text', 'grade', get_string('grade', 'mod_coursework'));
+            $mform->setType('grade', PARAM_RAW);
         } else {
             $mform->addElement('select',
                                'grade',
@@ -189,6 +192,8 @@ class assessor_feedback_mform extends moodleform {
              * @var gradingform_rubric_instance $grade
              */
             $feedback->grade = $gradinginstance->submit_and_get_grade($formdata->advancedgrading, $feedback->id);
+        } else if ($feedback->stage_identifier == 'final_agreed_1') {
+            $feedback->grade = format_float($formdata->grade, $coursework->get_grade_item()->get_decimals());
         } else {
             $feedback->grade = $formdata->grade;
         }

--- a/classes/models/coursework.php
+++ b/classes/models/coursework.php
@@ -73,6 +73,7 @@ defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 
+require_once($CFG->libdir . '/gradelib.php');
 require_once($CFG->dirroot.'/grade/grading/lib.php');
 
 /**
@@ -3085,5 +3086,25 @@ class coursework extends table_base {
         if (\core_plugin_manager::instance()->get_plugin_info('local_uolw_sits_data_import')) {
             user::fill_candidate_number_data($this);
         }
+    }
+
+    /**
+     * Get the primary grade item for this coursework instance.
+     *
+     * @return grade_item The grade_item record
+     */
+    public function get_grade_item() {
+        $params = ['itemtype' => 'mod',
+                        'itemmodule' => 'coursework',
+                        'iteminstance' => $this->id,
+                        'courseid' => $this->get_course_id(),
+                        'itemnumber' => 0];
+        $gradeitem = \grade_item::fetch($params);
+
+        if (!$gradeitem) {
+            throw new coding_exception('Cannot load the grade item.');
+        }
+
+        return $gradeitem;
     }
 }

--- a/tests/behat/behat_mod_coursework.php
+++ b/tests/behat/behat_mod_coursework.php
@@ -2195,9 +2195,9 @@ class behat_mod_coursework extends behat_base {
     }
 
     /**
-     * @Then /^I should( not)? see the final grade(?: as )?(\d+)? on the multiple marker page$/
+     * @Then /^I should( not)? see the final grade(?: as )?(\d*\.?\d+)? on the multiple marker page$/
      * @param bool $negate
-     * @param int $grade
+     * @param float $grade
      * @throws ExpectationException
      * @throws coding_exception
      */
@@ -2344,9 +2344,9 @@ class behat_mod_coursework extends behat_base {
 
     /**
      * Launch the grade submission modal and complete with grade/comment.
-     * @When /^I grade the submission(?: as )?(\d+)? using the ajax form(?: with comment "(?P<comment_string>(?:[^"]|\\")*)")?$/
+     * @When /^I grade the submission(?: as )?(\d*\.?\d+)? using the ajax form(?: with comment "(?P<comment_string>(?:[^"]|\\")*)")?$/
      *
-     * @param int $grade
+     * @param float $grade
      * @param string $comment
      * @throws Behat\Mink\Exception\ElementException
      * @throws Behat\Mink\Exception\ElementNotFoundException

--- a/tests/behat/grade_decimals.feature
+++ b/tests/behat/grade_decimals.feature
@@ -1,0 +1,46 @@
+@mod @mod_coursework @javascript
+Feature: For the final grade the mark should be to the decimal point
+
+  Background:
+    Given there is a course
+    And there is a coursework
+    And the coursework "numberofmarkers" setting is "2" in the database
+    And there is a teacher
+    And there is another teacher
+    And there is a student
+    And the student has a submission
+    And the submission is finalised
+
+  Scenario: Automatic agreement of grades = "average grade" should use decimal places
+    Given the coursework "automaticagreementstrategy" setting is "average_grade" in the database
+    And I am logged in as a teacher
+    And I visit the coursework page
+    And I expand the coursework grading row
+    And I click on the only interactable link with title "New feedback"
+    And I grade the submission as 59 using the ajax form
+    And I log out
+    And I log in as the other teacher
+    And I visit the coursework page
+    And I expand the coursework grading row
+    And I click on the only interactable link with title "New feedback"
+    And I grade the submission as 58 using the ajax form
+    Then I should see the final grade as 58.5 on the multiple marker page
+
+  Scenario: A manager can enter decimals for the final grade
+    Given I am logged in as a teacher
+    And I visit the coursework page
+    And I expand the coursework grading row
+    And I click on the only interactable link with title "New feedback"
+    And I grade the submission as 59 using the ajax form
+    And I log out
+    And I log in as the other teacher
+    And I visit the coursework page
+    And I expand the coursework grading row
+    And I click on the only interactable link with title "New feedback"
+    And I grade the submission as 58 using the ajax form
+    And I log out
+    And I log in as a manager
+    And I visit the coursework page
+    And I click the new multiple final feedback button for the student
+    And I grade the submission as 56.12 using the ajax form
+    Then I should see the final grade as 56.12 on the multiple marker page


### PR DESCRIPTION
Allow decimal points to be entered for the final grade, and when Automatic agreement of grades = "average grade".  The number of decimal places obtained from the Moodle grade book setting for the coursework instance (default: 2).