### PR TITLE
CTP-4162 moderated marking

### DIFF
--- a/classes/controllers/moderations_controller.php
+++ b/classes/controllers/moderations_controller.php
@@ -54,6 +54,11 @@ class moderations_controller extends controller_base {
     protected $moderation;
 
     /**
+     * @var feedback
+     */
+    protected $feedback;
+
+    /**
      * This deals with the page that the assessors see when they want to add component feedbacks.
      *
      * @throws \moodle_exception

--- a/classes/controllers/moderations_controller.php
+++ b/classes/controllers/moderations_controller.php
@@ -65,7 +65,7 @@ class moderations_controller extends controller_base {
         $moderatoragreement = new moderation();
         $moderatoragreement->submissionid = $this->params['submissionid'];
         $moderatoragreement->moderatorid = $this->params['moderatorid'];
-        $moderatoragreement->stage_identifier = $this->params['stage_identifier'];
+        $moderatoragreement->stageidentifier = $this->params['stage_identifier'];
         $moderatoragreement->courseworkid = $this->params['courseworkid'];
         $moderatoragreement->feedbackid = $this->params['feedbackid'];
 
@@ -77,7 +77,7 @@ class moderations_controller extends controller_base {
         $urlparams = [];
         $urlparams['submissionid'] = $moderatoragreement->submissionid;
         $urlparams['moderatorid'] = $moderatoragreement->moderatorid;
-        $urlparams['stage_identifier'] = $moderatoragreement->stage_identifier;
+        $urlparams['s'] = $moderatoragreement->stageidentifier;
         $urlparams['feedbackid'] = $moderatoragreement->feedbackid;
         $PAGE->set_url('/mod/coursework/actions/moderations/new.php', $urlparams);
 
@@ -96,7 +96,7 @@ class moderations_controller extends controller_base {
         global $DB, $PAGE, $USER;
 
         $moderation = new moderation($this->params['moderationid']);
-        $this->check_stage_permissions($moderation->stage_identifier);
+        $this->check_stage_permissions($moderation->stageidentifier);
 
         $ability = new ability(user::find($USER), $this->coursework);
         $ability->require_can('edit', $moderation);
@@ -127,7 +127,7 @@ class moderations_controller extends controller_base {
         $moderatoragreement = new moderation();
         $moderatoragreement->submissionid = $this->params['submissionid'];
         $moderatoragreement->moderatorid = $this->params['moderatorid'];
-        $moderatoragreement->stage_identifier = $this->params['stage_identifier'];
+        $moderatoragreement->stageidentifier = $this->params['stage_identifier'];
         $moderatoragreement->lasteditedby = $USER->id;
         $moderatoragreement->feedbackid = $this->params['feedbackid'];
 
@@ -176,7 +176,7 @@ class moderations_controller extends controller_base {
         $ability = new ability(user::find($USER), $this->coursework);
         $ability->require_can('edit', $moderatoragreement);
 
-        $this->check_stage_permissions($moderatoragreement->stage_identifier);
+        $this->check_stage_permissions($moderatoragreement->stageidentifier);
 
         $form = new moderator_agreement_mform(null, ['moderation' => $moderatoragreement]);
 

--- a/classes/forms/moderator_agreement_mform.php
+++ b/classes/forms/moderator_agreement_mform.php
@@ -68,7 +68,7 @@ class moderator_agreement_mform extends moodleform {
         $mform->addElement('hidden', 'moderatorid', $moderation->moderatorid);
         $mform->setType('moderatorid', PARAM_INT);
 
-        $mform->addElement('hidden', 'stage_identifier', $moderation->stage_identifier);
+        $mform->addElement('hidden', 'stage_identifier', $moderation->stageidentifier);
         $mform->setType('stage_identifier', PARAM_ALPHANUMEXT);
 
         $mform->addElement('hidden', 'feedbackid', $feedback->id);

--- a/classes/framework/table_base.php
+++ b/classes/framework/table_base.php
@@ -58,6 +58,26 @@ abstract class table_base {
     public $id;
 
     /**
+     * @var int
+     */
+    public $timecreated;
+
+    /**
+     * @var int
+     */
+    public $timemodified;
+
+    /**
+     * @var int
+     */
+    public $lasteditedby;
+
+    /**
+     * @var stdClass
+     */
+    public $moderator;
+
+    /**
      * Makes a new instance. Can be overridden to provide a factory
      *
      * @param \stdClass|int|array $dbrecord

--- a/classes/framework/table_base.php
+++ b/classes/framework/table_base.php
@@ -225,7 +225,7 @@ abstract class table_base {
      * without having to juggle build and find elsewhere.
      *
      * @param array $params
-     * @return table_base
+     * @return object
      */
     public static function find_or_build($params) {
         $object = self::find($params);

--- a/classes/models/moderation.php
+++ b/classes/models/moderation.php
@@ -56,13 +56,13 @@ class moderation extends table_base {
     public $moderatorid;
 
     /**
-     * @var int
+     * @var string
      */
     public $stageidentifier = 'moderator';
+
     /**
      * @var string
      */
-
     public $agreement;
 
     /**

--- a/classes/models/moderation.php
+++ b/classes/models/moderation.php
@@ -86,6 +86,16 @@ class moderation extends table_base {
     private $submission;
 
     /**
+     * @var submissionid
+     */
+    public $submissionid;
+
+    /**
+     * @var courseworkid
+     */
+    public $courseworkid;
+
+    /**
      * Chained getter for loose coupling.
      *
      * @return coursework

--- a/tests/behat/behat_mod_coursework.php
+++ b/tests/behat/behat_mod_coursework.php
@@ -2096,6 +2096,17 @@ class behat_mod_coursework extends behat_base {
     }
 
     /**
+     * @When /^I click the edit moderation agreement link$/
+     */
+    public function i_click_the_edit_moderation_agreement_link() {
+        /**
+         * @var mod_coursework_behat_multiple_grading_interface $page
+         */
+        $page = $this->get_page('multiple grading interface');
+        $page->click_edit_moderation_agreement_link($this->student);
+    }
+
+    /**
      * @Given /^I should see the moderator grade on the page$/
      */
     public function i_should_see_the_moderator_grade_on_the_page() {

--- a/tests/behat/moderation_edit.feature
+++ b/tests/behat/moderation_edit.feature
@@ -1,0 +1,18 @@
+@mod @mod_coursework @javascript
+Feature: Moderation of feedback
+
+  Scenario: When I moderate feedback then edit the moderation by clicking the pencil button the moderation form should load with no error
+    Given there is a course
+    And there is a coursework
+    And there is a student
+    And there is a teacher
+    And the coursework "numberofmarkers" setting is "1" in the database
+    And the coursework "moderationagreementenabled" setting is "1" in the database
+    And the student has a submission
+    And there is feedback for the submission from the teacher
+    And I log in as "admin"
+    And I visit the coursework page
+    And I click on "Moderate" "link"
+    And I click on "Save changes" "button"
+    When I click the edit moderation agreement link
+    Then I should see "Moderation agreement"

--- a/tests/behat/pages/multiple_grading_interface.php
+++ b/tests/behat/pages/multiple_grading_interface.php
@@ -137,6 +137,15 @@ class mod_coursework_behat_multiple_grading_interface extends mod_coursework_beh
     }
 
     /**
+     * @param allocatable $student
+     * @throws Behat\Mink\Exception\ElementException
+     */
+    public function click_edit_moderation_agreement_link($student) {
+        $identifier = $this->allocatable_row_id($student) . ' .moderation_agreement_cell .action-icon';
+        $this->getPage()->find('css', $identifier)->click();
+    }
+
+    /**
      * @param allocatable $allocatable
      * @param int $assessornumber
      * @param int $expectedgrade


### PR DESCRIPTION
Fixed "typo": replacing "$stageidentifier" with "$stage_identifier" in the moderation class. 
This fixes the issue and is now in sync with other uses of this attribute elsewhere.
I also fixed issues with dynamic property so far..