### PR TITLE
CTP-4655 show in Feedback Tracker report and My Feedback block

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Behat features
         if: ${{ !cancelled() }}
-        run: moodle-plugin-ci behat --profile headlessfirefox
+        run: moodle-plugin-ci behat --profile firefox
 
       - name: Mark cancelled jobs as failed.
         if: ${{ cancelled() }}

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Behat features
         if: ${{ !cancelled() }}
-        run: moodle-plugin-ci behat --profile firefox
+        run: moodle-plugin-ci behat --profile headlessfirefox
 
       - name: Mark cancelled jobs as failed.
         if: ${{ cancelled() }}

--- a/classes/export/csv/cells/agreedfeedback_cell.php
+++ b/classes/export/csv/cells/agreedfeedback_cell.php
@@ -76,7 +76,7 @@ class agreedfeedback_cell extends cell_base {
             $submission = \mod_coursework\models\submission::find($subdbrecord);
 
             // Is the submission in question ready to grade?
-            if (!$submission->all_inital_graded() && !empty($value)) {
+            if (!$submission->all_initial_graded() && !empty($value)) {
                 return get_string('submissionnotreadyforagreedgrade', 'coursework');
             }
 

--- a/classes/export/csv/cells/agreedgrade_cell.php
+++ b/classes/export/csv/cells/agreedgrade_cell.php
@@ -156,7 +156,7 @@ class agreedgrade_cell extends cell_base {
             $submission = \mod_coursework\models\submission::find($subdbrecord);
 
             // Is the submission in question ready to grade?
-            if (!$submission->all_inital_graded() && !empty($value) && count($uploadedgradecells) < $submission->max_number_of_feedbacks()) { return get_string('submissionnotreadyforagreedgrade', 'coursework');
+            if (!$submission->all_initial_graded() && !empty($value) && count($uploadedgradecells) < $submission->max_number_of_feedbacks()) { return get_string('submissionnotreadyforagreedgrade', 'coursework');
             }
 
             // Has the submission been published if yes then no further grades are allowed

--- a/classes/framework/table_base.php
+++ b/classes/framework/table_base.php
@@ -31,6 +31,7 @@ defined('MOODLE_INTERNAL') || die();
  *
  * @property mixed fields
  */
+#[\AllowDynamicProperties]
 abstract class table_base {
 
     /**
@@ -56,26 +57,6 @@ abstract class table_base {
      * @var int
      */
     public $id;
-
-    /**
-     * @var int
-     */
-    public $timecreated;
-
-    /**
-     * @var int
-     */
-    public $timemodified;
-
-    /**
-     * @var int
-     */
-    public $lasteditedby;
-
-    /**
-     * @var stdClass
-     */
-    public $moderator;
 
     /**
      * Makes a new instance. Can be overridden to provide a factory

--- a/classes/framework/table_base.php
+++ b/classes/framework/table_base.php
@@ -31,7 +31,7 @@ defined('MOODLE_INTERNAL') || die();
  *
  * @property mixed fields
  */
-#[\AllowDynamicProperties]
+#[\AllowDynamicProperties] // Allow dynamic properties for table_base to avoid interferences elsewhere.
 abstract class table_base {
 
     /**

--- a/classes/models/moderation.php
+++ b/classes/models/moderation.php
@@ -66,7 +66,7 @@ class moderation extends table_base {
     public $lasteditedby;
 
     /**
-     * @var int
+     * @var string
      */
     public $stageidentifier = 'moderator';
 

--- a/classes/models/submission.php
+++ b/classes/models/submission.php
@@ -880,7 +880,7 @@ class submission extends table_base implements \renderable {
     /**
      * @return bool
      */
-    public function all_inital_graded() {
+    public function all_initial_graded() {
         return $this->get_state() >= self::FULLY_GRADED;
     }
 
@@ -1436,7 +1436,7 @@ class submission extends table_base implements \renderable {
         if ($this->get_coursework()->get_max_markers() == 1) {
             $canadd = (has_any_capability(['mod/coursework:addinitialgrade', 'mod/coursework:addministergrades'], $this->get_context()) && $this->ready_to_grade());
         } else {
-            $canadd = (has_any_capability(['mod/coursework:addagreedgrade', 'mod/coursework:addallocatedagreedgrade', 'mod/coursework:addministergrades'], $this->get_context()) && $this->all_inital_graded());
+            $canadd = (has_any_capability(['mod/coursework:addagreedgrade', 'mod/coursework:addallocatedagreedgrade', 'mod/coursework:addministergrades'], $this->get_context()) && $this->all_initial_graded());
         }
 
         return  $canadd;

--- a/classes/services/submission_figures.php
+++ b/classes/services/submission_figures.php
@@ -39,7 +39,6 @@ class submission_figures {
      * @return array
      */
     public static function get_submissions_for_assessor(int $instance): array {
-        global $USER;
 
         $coursework = coursework::find($instance);
         $context = $coursework->get_context();
@@ -176,7 +175,6 @@ class submission_figures {
      * @return array
      */
     private static function get_assessor_initial_graded_submissions(array $submissions): array {
-        global $USER;
 
         foreach ($submissions as $submission) {
             $hasallfeedbacks = count($submission->get_assessor_feedbacks()) >= $submission->max_number_of_feedbacks();

--- a/classes/services/submission_figures.php
+++ b/classes/services/submission_figures.php
@@ -1,0 +1,233 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Services for submission and grading figures.
+ *
+ * @package    mod_coursework
+ * @copyright  2025 UCL <m.opitz@ucl.ac.uk>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_coursework\services;
+
+use mod_coursework\models\submission;
+
+/**
+ * Class to provide figures around submissions and gradings.
+ */
+class submission_figures {
+
+    /**
+     * Get the submissions for current user as assessor.
+     *
+     * @param mixed $coursework
+     * @return array
+     */
+    public static function get_submissions_for_assessor($coursework): array {
+        global $USER;
+
+        $gradeblesub = [];
+        $context = $coursework->get_context();
+        $submissions = $coursework->get_all_submissions();
+
+        if (!$coursework->has_multiple_markers()
+            && has_capability('mod/coursework:addagreedgrade', $coursework->get_context())
+            && !has_capability('mod/coursework:addinitialgrade', $context)) {
+
+            foreach ($submissions as $sub) {
+                $submission = submission::find($sub);
+                if ( $submission->final_grade_agreed()) {
+                    continue;
+                } else if (count($submission->get_assessor_feedbacks()) < $submission->max_number_of_feedbacks()) {
+                    unset($submissions[$submission->id]);
+                }
+            }
+
+            $gradeblesub = $submissions;
+
+        } else if (is_siteadmin($USER) ||
+            !$coursework->allocation_enabled() ||
+            has_any_capability(['mod/coursework:administergrades'], $context)) {
+            foreach ($submissions as $sub) {
+                $submission = submission::find($sub);
+                $gradeblesub[$submission->id] = $submission;
+            }
+
+        } else {
+            foreach ($submissions as $sub) {
+                $submission = submission::find($sub);
+                if ($coursework->assessor_has_any_allocation_for_student($submission->reload()->get_allocatable()) ||
+                    (has_capability('mod/coursework:addagreedgrade', $context))
+                    && !empty($submission)
+                    && (($submission->all_inital_graded()
+                            && !$submission->get_coursework()->sampling_enabled())
+                        || ($submission->get_coursework()->sampling_enabled()
+                            && $submission->all_inital_graded()
+                            && $submission->max_number_of_feedbacks() > 1))) {
+                    $gradeblesub[$submission->id] = $submission;
+                }
+            }
+        }
+
+        return $gradeblesub;
+    }
+
+    /**
+     * Calculate the needed gradings for the current user as assessor.
+     *
+     * @param mixed $coursework
+     * @return int
+     */
+    public static function calculate_needsgrading_for_assessor($coursework): int {
+        $needsgrading = 0;
+        $context = $coursework->get_context();
+
+        if (!$coursework->has_multiple_markers()
+                && !$coursework->allocation_enabled()
+                && !has_capability('mod/coursework:addinitialgrade', $context)
+                && has_capability('mod/coursework:addagreedgrade', $context)) {
+            return $needsgrading;
+        }
+
+        $submissions = self::get_submissions_for_assessor($coursework);
+
+        // Remove unwanted submissions.
+        $submissions = self::remove_unfinalised_submissions($submissions);
+        $submissions = self::remove_ungradable_submissions($submissions);
+        $submissions = self::removed_final_graded_submissions($submissions);
+
+        $canfinalgrade = has_any_capability([
+                'mod/coursework:addagreedgrade',
+                'mod/coursework:administergrades',
+            ], $context) || (
+                has_capability('mod/coursework:addinitialgrade', $context)
+                    && has_capability('mod/coursework:addallocatedagreedgrade', $context)
+            );
+
+        if ($canfinalgrade) {
+            $total = count($submissions);
+            $remaining = self::remove_final_gradable_submissions($submissions);
+            $needsgrading += ($total - count($remaining));
+        }
+
+        $caninitialgrade = has_any_capability([
+            'mod/coursework:addinitialgrade',
+            'mod/coursework:administergrades',
+        ], $context);
+
+        if ($caninitialgrade) {
+            $submissions = self::remove_final_gradable_submissions($submissions);
+            $needsgrading += count(self::get_assessor_initial_graded_submissions($submissions));
+        }
+
+        return $needsgrading;
+    }
+
+    /**
+     * Remove final unfinalised submissions from an array of submissions.
+     *
+     * @param array $submissions
+     * @return array
+     */
+    private static function remove_unfinalised_submissions(array $submissions): array {
+        foreach ($submissions as $sub) {
+            $submission = submission::find($sub);
+
+            if (empty($submission->finalised)) {
+                unset($submissions[$sub->id]);
+            }
+        }
+        return $submissions;
+    }
+
+    /**
+     * Remove final ungradable submissions from an array of submissions.
+     *
+     * @param array $submissions
+     * @return array
+     */
+    private static function remove_ungradable_submissions(array $submissions): array {
+        foreach ($submissions as $sub) {
+            $submission = submission::find($sub);
+
+            if (has_capability('mod/coursework:addallocatedagreedgrade', $submission->get_coursework()->get_context())
+                && !$submission->is_assessor_initial_grader() && $submission->all_inital_graded()) {
+                unset($submissions[$sub->id]);
+            }
+        }
+        return $submissions;
+    }
+
+    /**
+     * Remove final graded submissions from an array of submissions.
+     *
+     * @param array $submissions
+     * @return array
+     */
+    private static function removed_final_graded_submissions(array $submissions): array {
+        foreach ($submissions as $sub) {
+            $submission = submission::find($sub);
+
+            if (!empty($submission->get_final_grade() )) {
+                unset($submissions[$sub->id]);
+            }
+        }
+        return $submissions;
+    }
+
+    /**
+     * Remove final gradable submissions from an array of submissions.
+     *
+     * @param array $submissions
+     * @return array
+     */
+    private static function remove_final_gradable_submissions(array $submissions): array {
+        foreach ($submissions as $sub) {
+            $submission = submission::find($sub);
+
+            if (!empty($submission->all_inital_graded()) ) {
+                unset($submissions[$sub->id]);
+            }
+        }
+        return $submissions;
+    }
+
+    /**
+     * Get the initial graded submissions dor the assessor.
+     *
+     * @param array $submissions
+     * @return array
+     */
+    private static function get_assessor_initial_graded_submissions(array $submissions): array {
+        global $USER;
+
+        foreach ($submissions as $sub) {
+            $submission = submission::find($sub);
+
+            if (count($submission->get_assessor_feedbacks()) >= $submission->max_number_of_feedbacks()
+                    || $submission->is_assessor_initial_grader()
+                    && (!has_capability('mod/coursework:administergrades',
+                            $submission->get_coursework()->get_context())
+                        && !is_siteadmin($USER->id))) {
+
+                // Is this submission assessable by this user at an initial grading stage.
+                unset($submissions[$sub->id]);
+            }
+        }
+        return $submissions;
+    }
+}

--- a/classes/services/submission_figures.php
+++ b/classes/services/submission_figures.php
@@ -73,7 +73,7 @@ class submission_figures {
             } else {
                 $allocated = $coursework->assessor_has_any_allocation_for_student($submission->reload()->get_allocatable());
                 $sampled = $submission->get_coursework()->sampling_enabled();
-                $initialgraded = $submission->all_inital_graded();
+                $initialgraded = $submission->all_initial_graded();
                 $requiresamplingcheck = $sampled && ($submission->max_number_of_feedbacks() > 1);
 
                 if ($allocated || ($canaddagreed && $initialgraded && (!$sampled || $requiresamplingcheck))) {
@@ -146,7 +146,7 @@ class submission_figures {
             if (empty($submission->finalised)
                 || !empty($submission->get_final_grade())
                 || (has_capability('mod/coursework:addallocatedagreedgrade', $submission->get_coursework()->get_context())
-                    && !$submission->is_assessor_initial_grader() && $submission->all_inital_graded())) {
+                    && !$submission->is_assessor_initial_grader() && $submission->all_initial_graded())) {
                 unset($submissions[$submission->id]);
             }
         }
@@ -161,7 +161,7 @@ class submission_figures {
      */
     private static function remove_final_gradable_submissions(array $submissions): array {
         foreach ($submissions as $submission) {
-            if (!empty($submission->all_inital_graded()) ) {
+            if (!empty($submission->all_initial_graded()) ) {
                 unset($submissions[$submission->id]);
             }
         }

--- a/renderers/object_renderer.php
+++ b/renderers/object_renderer.php
@@ -1419,8 +1419,8 @@ class mod_coursework_object_renderer extends plugin_renderer_base {
                 $submission = $allocatable->get_submission($coursework);
 
                 if ($coursework->assessor_has_any_allocation_for_student($allocatable) || has_capability('mod/coursework:addagreedgrade', $coursework->get_context())
-                    && !empty($submission) && (($submission->all_inital_graded() && !$coursework->sampling_enabled())
-                        || ($coursework->sampling_enabled() && $submission->all_inital_graded() && $submission->max_number_of_feedbacks() > 1 ))) {
+                    && !empty($submission) && (($submission->all_initial_graded() && !$coursework->sampling_enabled())
+                        || ($coursework->sampling_enabled() && $submission->all_initial_graded() && $submission->max_number_of_feedbacks() > 1 ))) {
                     $participant  ++;
                 }
             }
@@ -1482,7 +1482,7 @@ class mod_coursework_object_renderer extends plugin_renderer_base {
 
             $submission = submission::find($sub);
 
-            if (has_capability('mod/coursework:addallocatedagreedgrade', $submission->get_coursework()->get_context()) && !$submission->is_assessor_initial_grader() && $submission->all_inital_graded()) {
+            if (has_capability('mod/coursework:addallocatedagreedgrade', $submission->get_coursework()->get_context()) && !$submission->is_assessor_initial_grader() && $submission->all_initial_graded()) {
                 unset($submissions[$sub->id]);
             }
         }
@@ -1501,7 +1501,7 @@ class mod_coursework_object_renderer extends plugin_renderer_base {
         foreach ($submissions as $sub) {
 
             $submission = submission::find($sub);
-            if (!empty($submission->all_inital_graded()) ) {
+            if (!empty($submission->all_initial_graded()) ) {
                 unset($submissions[$sub->id]);
             }
         }
@@ -1527,7 +1527,7 @@ class mod_coursework_object_renderer extends plugin_renderer_base {
             if (count($submission->get_assessor_feedbacks()) >= $submission->max_number_of_feedbacks() || $submission->is_assessor_initial_grader()
                 && (!has_capability('mod/coursework:administergrades', $submission->get_coursework()->get_context()) && !is_siteadmin($USER->id))) {
 
-                // Is this submission assessable by this user at an inital gradig stage
+                // Is this submission assessable by this user at an initial gradig stage
                 unset($submissions[$sub->id]);
             }
         }
@@ -1595,8 +1595,8 @@ class mod_coursework_object_renderer extends plugin_renderer_base {
             foreach ($submissions as $sub) {
                 $submission = submission::find($sub);
                 if ($coursework->assessor_has_any_allocation_for_student($submission->reload()->get_allocatable()) || (has_capability('mod/coursework:addagreedgrade', $coursework->get_context()))
-                    && !empty($submission) && (($submission->all_inital_graded() && !$submission->get_coursework()->sampling_enabled())
-                        || ($submission->get_coursework()->sampling_enabled() && $submission->all_inital_graded() && $submission->max_number_of_feedbacks() > 1))) {
+                    && !empty($submission) && (($submission->all_initial_graded() && !$submission->get_coursework()->sampling_enabled())
+                        || ($submission->get_coursework()->sampling_enabled() && $submission->all_initial_graded() && $submission->max_number_of_feedbacks() > 1))) {
 
                     $gradeblesub[$submission->id] = $submission;
                 }

--- a/tests/behat/moderation_edit.feature
+++ b/tests/behat/moderation_edit.feature
@@ -1,0 +1,18 @@
+@mod @mod_coursework @javascript
+Feature: Moderation of feedback
+
+  Scenario: When I moderate feedback then edit the moderation by clicking the pencil button the moderation form should load with no error
+    Given there is a course
+    And there is a coursework
+    And there is a student
+    And there is a teacher
+    And the coursework "numberofmarkers" setting is "1" in the database
+    And the coursework "moderationagreementenabled" setting is "1" in the database
+    And the student has a submission
+    And there is feedback for the submission from the teacher
+    And I log in as "admin"
+    And I visit the coursework page
+    And I click on "Moderate" "link"
+    And I click on "Save changes" "button"
+    When I click the edit moderation agreement link
+    Then I should see "Moderation agreement"

--- a/tests/behat/moderation_view.feature
+++ b/tests/behat/moderation_view.feature
@@ -1,0 +1,24 @@
+@mod @mod_coursework @javascript
+Feature: View moderation feedback
+
+  Scenario: As an assessor I’ve received some moderation and when I view this I should see the moderator's feedback with no error
+    Given there is a course
+    And there is a coursework
+    And there is a student
+    And there is a teacher
+    And the following "permission overrides" exist:
+      | capability                             | permission | role    | contextlevel | reference |
+      | mod/coursework:viewallgradesatalltimes | Allow      | teacher | Course       | C1        |
+    And the coursework "numberofmarkers" setting is "1" in the database
+    And the coursework "moderationagreementenabled" setting is "1" in the database
+    And the student has a submission
+    And there is feedback for the submission from the teacher
+    And I log in as "admin"
+    And I visit the coursework page
+    And I click on "Moderate" "link"
+    And I click on "Save changes" "button"
+    And I log out
+    And I log in as the teacher
+    And I visit the coursework page
+    When I click on "View moderation" "link"
+    Then I should see "Moderation for student"


### PR DESCRIPTION
As there was no dedicated method to provide assessor/marker related figures I have created a new class and put it there.
So far methods to return all submissions and submissions in need of grading for the current user as assessor have been created.

The logic has been blatantly copied and adopted from the mod_coursework_object_renderer class leaving it there (so we have duplicate code for now but I assume that you may have refactored the renderers anyway?)
