### PR TITLE
CTP-4215 grading table row permission

### DIFF
--- a/classes/ability.php
+++ b/classes/ability.php
@@ -208,7 +208,6 @@ class ability extends \mod_coursework\framework\ability {
         $this->allow_show_grading_table_row_if_user_can_grant_extension_and_no_allocation();
         // CTP-4215 external examiner with capability mod/coursework:viewallgradesatalltimes needs to see all submissions.
         $this->allow_show_grading_table_row_if_user_can_view_grades_at_all_times();
-        $this->allow_show_grading_table_row_if_user_can_grant_extension_and_no_allocation();
         $this->allow_show_grading_table_row_if_user_can_submit_on_behalf_of();
         $this->allow_show_grading_table_row_if_user_can_export_final_grades();
 

--- a/classes/ability.php
+++ b/classes/ability.php
@@ -201,12 +201,16 @@ class ability extends \mod_coursework\framework\ability {
 
         // Show grading table row
         $this->allow_show_grading_table_row_if_allocation_enabled_and_user_has_any_allocation();
-
         $this->allow_show_grading_table_row_if_allocation_enabled_and_all_initial_feedback_done_and_user_can_do_agreed_grades();
         $this->allow_show_grading_table_row_if_allocation_not_enabled_and_user_is_assessor_of_any_stage();
         $this->allow_show_grading_table_row_if_user_has_added_feedback_for_this_submission();
         $this->allow_show_grading_table_row_if_user_can_administer_grades();
         $this->allow_show_grading_table_row_if_user_can_grant_extension_and_no_allocation();
+        // CTP-4215 external examiner with capability mod/coursework:viewallgradesatalltimes needs to see all submissions.
+        $this->allow_show_grading_table_row_if_user_can_view_grades_at_all_times();
+        $this->allow_show_grading_table_row_if_user_can_grant_extension_and_no_allocation();
+        $this->allow_show_grading_table_row_if_user_can_submit_on_behalf_of();
+        $this->allow_show_grading_table_row_if_user_can_export_final_grades();
 
         // Deadline extension rules
 


### PR DESCRIPTION
This is strange in that the 4 x methods I included in this commit already existed in the ability class at `mod/coursework/classes/ability.php` but were not being called.  I can't see any reference to them elsewhere.  However with these added the external examiner has the rows