### PR TITLE
CTP-5102 Use language string

### DIFF
--- a/lang/en/coursework.php
+++ b/lang/en/coursework.php
@@ -508,6 +508,7 @@ $string['marking_deadline_default'] = 'Initial marking deadline';
 $string['marking_deadline_enabled_desc'] = 'Select the default initial marking deadline applied to coursework activities';
 $string['markerdefaultname'] = 'Marker {$a}';
 $string['markingcriteriafeedback'] = 'Marking criteria feedback';
+$string['markingsummary'] = 'Marking summary';
 $string['markingworkflow'] = 'Marking workflow';
 $string['marks_released'] = 'Marks released';
 $string['maxfeedbacks'] = '(Max: {$a} feedbacks)';

--- a/templates/marking_summary.mustache
+++ b/templates/marking_summary.mustache
@@ -39,7 +39,7 @@
     }
 }}
 <div class="bg-light p-3">
-    <h3 class="h5" id="marking-summary-title">Marking summary</h3>
+    <h3 class="h5" id="marking-summary-title">{{#str}} markingsummary, mod_coursework {{/str}}</h3>
 
     {{^canmark}}
     <p>{{#str}} nomarkercap, mod_coursework {{/str}}</p>


### PR DESCRIPTION
`templates/marking_summary.mustache` had a hard-coded string, an oversight from CTP-4855.

Now changed to use a language string.