### PR TITLE
CTP-3829 add indices

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -135,6 +135,9 @@
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
         <KEY NAME="courseworkid-id" TYPE="foreign" FIELDS="courseworkid" REFTABLE="coursework" REFFIELDS="id" COMMENT="links the coursework and submission tables"/>
       </KEYS>
+        <INDEXES>
+            <INDEX NAME="courseworkid-allocatableid-allocatabletype" UNIQUE="false" FIELDS="courseworkid, allocatableid, allocatabletype"/>
+        </INDEXES>
     </TABLE>
     <TABLE NAME="coursework_reminder" COMMENT="coursework reminder">
       <FIELDS>
@@ -227,6 +230,9 @@
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
       </KEYS>
+        <INDEXES>
+            <INDEX NAME="courseworkid-allocatableid-allocatabletype" UNIQUE="false" FIELDS="courseworkid, allocatableid, allocatabletype"/>
+        </INDEXES>
     </TABLE>
     <TABLE NAME="coursework_sample_set_rules" COMMENT="Automatic sample sets for each coursework stage. This allows us to keep track of which rules have been added. The order matters as some will be top-up rules.">
       <FIELDS>
@@ -285,6 +291,9 @@
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
       </KEYS>
+        <INDEXES>
+            <INDEX NAME="courseworkid-allocatableid-allocatabletype" UNIQUE="false" FIELDS="courseworkid, allocatableid, allocatabletype"/>
+        </INDEXES>
     </TABLE>
 
     <TABLE NAME="coursework_mod_agreements" COMMENT="Stores moderation agreements.">

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -2552,6 +2552,26 @@ function xmldb_coursework_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2025082800, 'coursework');
     }
 
+    if ($oldversion < 2025100300) {
+        $tablestoaddindex = ['coursework_submissions', 'coursework_extensions', 'coursework_person_deadlines'];
+        foreach ($tablestoaddindex as $tablename) {
+            // Define index courseworkid-allocatableid-allocatabletype (not unique) to be added to table.
+            $table = new xmldb_table($tablename);
+            $index = new xmldb_index(
+                'courseworkid-allocatableid-allocatabletype',
+                XMLDB_INDEX_NOTUNIQUE,
+                ['courseworkid', 'allocatableid', 'allocatabletype']
+            );
+
+            // Conditionally launch add index courseworkid-allocatableid-allocatabletype.
+            if (!$dbman->index_exists($table, $index)) {
+                $dbman->add_index($table, $index);
+            }
+        }
+        // Coursework savepoint reached.
+        upgrade_mod_savepoint(true, 2025100300, 'coursework');
+    }
+
     // Always needs to return true.
     return true;
 }

--- a/version.php
+++ b/version.php
@@ -24,10 +24,10 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_coursework';
 
-$plugin->version = 2025090800;  // If version == 0 then module will not be installed
-$plugin->requires = 2023100400;  // Requires this Moodle version
+$plugin->version = 2025100300;  // If version == 0 then module will not be installed.
+$plugin->requires = 2024100100;  // Requires this Moodle version.
 
 $plugin->cron = 300;        // Period for cron to check this module (secs).
 
-$plugin->release = "4.3.0";
+$plugin->release = "4.5.0";
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
The tables coursework_submissions, coursework_extensions and coursework_person_deadlines are often queried with courseworkid, allocatableid and allocatabletype in the WHERE clause, yet the tables have no suitable index to use.   For example on the grading page, such queries are run repeatedly by the ability class with no caching.  (Caching may be worth considering separately but for now this is to add some indices)