### PR TITLE
CTP-5051 Fix finalstagegrading setting visibility

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -1143,7 +1143,7 @@ class mod_coursework_mod_form extends moodleform_mod {
 
         $moodleform->addElement('hidden', 'feedbackexists', $feedbackexists);
         $moodleform->setType('feedbackexists', PARAM_INT);
-        $moodleform->hideif('finalstagegrading', 'feedbackexists', 'eq', 1);
+        $moodleform->disabledIf('finalstagegrading', 'feedbackexists', 'eq', 1);
 
         // Don't think this belongs here...
         // $options = array(0 => get_string('no'), 1 => get_string('yes'));


### PR DESCRIPTION
Previously with multiple markers and Grading method = "Marking guide" the Grading method for final stage setting was hidden once there was final feedback. Now this setting is disabled so one can review but not change this setting once there is final feedback.