### PR TITLE
Ctp 5007 grading table performance

### DIFF
--- a/classes/ability.php
+++ b/classes/ability.php
@@ -29,7 +29,6 @@ use mod_coursework\models\deadline_extension;
 use mod_coursework\models\personal_deadline;
 use mod_coursework\models\feedback;
 use mod_coursework\models\submission;
-use mod_coursework\models\user;
 use mod_coursework\models\moderation;
 use mod_coursework\models\plagiarism_flag;
 

--- a/classes/allocation/allocatable.php
+++ b/classes/allocation/allocatable.php
@@ -52,13 +52,7 @@ interface allocatable {
     /**
      * @return string
      */
-    public function picture();
-
-    /**
-     * @param bool $withpicture
-     * @return string
-     */
-    public function profile_link($withpicture = false);
+    public function profile_link();
 
     /**
      * @param \stdClass $course

--- a/classes/controllers/deadline_extensions_controller.php
+++ b/classes/controllers/deadline_extensions_controller.php
@@ -46,7 +46,7 @@ class deadline_extensions_controller extends controller_base {
     protected function show_deadline_extension() {
         global $USER, $PAGE;
 
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         $ability->require_can('show', $this->deadlineextension);
 
         $PAGE->set_url('/mod/coursework/actions/deadline_extensions/show.php', $this->params);
@@ -58,7 +58,7 @@ class deadline_extensions_controller extends controller_base {
         global $USER, $PAGE;
 
         $params = $this->set_default_current_deadline();
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         $ability->require_can('new', $this->deadlineextension);
 
         $PAGE->set_url('/mod/coursework/actions/deadline_extensions/new.php', $params);
@@ -112,7 +112,7 @@ class deadline_extensions_controller extends controller_base {
             $data->extra_information_format = $data->extra_information['format'];
             $this->deadlineextension = deadline_extension::build($data);
 
-            $ability = new ability(user::find($USER), $this->coursework);
+            $ability = new ability($USER->id, $this->coursework);
             $ability->require_can('create', $this->deadlineextension);
 
             $this->deadlineextension->save();
@@ -157,7 +157,7 @@ class deadline_extensions_controller extends controller_base {
         ];
         $this->deadlineextension = deadline_extension::find($params);
 
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         $ability->require_can('edit', $this->deadlineextension);
 
         $PAGE->set_url('/mod/coursework/actions/deadline_extensions/edit.php', $params);
@@ -181,7 +181,7 @@ class deadline_extensions_controller extends controller_base {
     public function delete_deadline_extension(): bool {
         global $USER;
         $extensionid = $this->params['extensionid'];
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         $deadlineextension = deadline_extension::find(['id' => $extensionid]);
         if ($deadlineextension && $deadlineextension->can_be_deleted()) {
             $ability->require_can('edit', $deadlineextension);
@@ -213,7 +213,7 @@ class deadline_extensions_controller extends controller_base {
         if ($this->cancel_button_was_pressed()) {
             redirect($courseworkpageurl);
         }
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         $values = $this->form->get_data();
         $this->deadlineextension = deadline_extension::find(['id' => $this->params['id']]);
 

--- a/classes/controllers/feedback_controller.php
+++ b/classes/controllers/feedback_controller.php
@@ -58,14 +58,11 @@ class feedback_controller extends controller_base {
         $PAGE->set_url('/mod/coursework/actions/feedbacks/show.php', $urlparams);
         $teacherfeedback = new feedback($this->params['feedbackid']);
 
-        $user = user::find($USER);
-        if ($user) {
-            $ability = new ability($user, $this->coursework);
-            $ability->require_can('show', $teacherfeedback);
-            $renderer = $this->get_page_renderer();
-            $html = $renderer->show_feedback_page($teacherfeedback);
-            echo $html;
-        }
+        $ability = new ability($USER->id, $this->coursework);
+        $ability->require_can('show', $teacherfeedback);
+        $renderer = $this->get_page_renderer();
+        $html = $renderer->show_feedback_page($teacherfeedback);
+        echo $html;
     }
 
     /**
@@ -93,7 +90,7 @@ class feedback_controller extends controller_base {
             }
         }
 
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         if (!$ability->can('new', $teacherfeedback)) {
             throw new access_denied($this->coursework, $ability->get_last_message());
         }
@@ -124,7 +121,7 @@ class feedback_controller extends controller_base {
         $teacherfeedback = new feedback($this->params['feedbackid']);
         $this->check_stage_permissions($teacherfeedback->stage_identifier);
 
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         $ability->require_can('edit', $teacherfeedback);
 
         $urlparams = ['feedbackid' => $this->params['feedbackid']];
@@ -185,7 +182,7 @@ class feedback_controller extends controller_base {
             }
         }
 
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         $ability->require_can('create', $teacherfeedback);
 
         $form = new assessor_feedback_mform(null, ['feedback' => $teacherfeedback]);
@@ -240,7 +237,7 @@ class feedback_controller extends controller_base {
         $teacherfeedback->lasteditedbyuser = $USER->id;
         $teacherfeedback->finalised = $this->params['finalised'] ? 1 : 0;
 
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         $ability->require_can('update', $teacherfeedback);
         $courseworkpageurl = $this->get_path('coursework', ['coursework' => $teacherfeedback->get_coursework()]);
 
@@ -367,7 +364,7 @@ class feedback_controller extends controller_base {
         global $USER;
 
         $stage = $this->coursework->get_stage($identifier);
-        if (!$stage->user_is_assessor($USER)) {
+        if (!$stage->user_is_assessor($USER->id)) {
             if (!(has_capability('mod/coursework:administergrades', $this->coursework->get_context()) ||
                   has_capability('mod/coursework:addallocatedagreedgrade', $this->coursework->get_context())) ) {
                 throw new access_denied(

--- a/classes/controllers/feedback_controller.php
+++ b/classes/controllers/feedback_controller.php
@@ -61,8 +61,7 @@ class feedback_controller extends controller_base {
         $ability = new ability($USER->id, $this->coursework);
         $ability->require_can('show', $teacherfeedback);
         $renderer = $this->get_page_renderer();
-        $html = $renderer->show_feedback_page($teacherfeedback);
-        echo $html;
+        echo $renderer->show_feedback_page($teacherfeedback);
     }
 
     /**

--- a/classes/controllers/moderations_controller.php
+++ b/classes/controllers/moderations_controller.php
@@ -74,7 +74,7 @@ class moderations_controller extends controller_base {
         $moderatoragreement->courseworkid = $this->params['courseworkid'];
         $moderatoragreement->feedbackid = $this->params['feedbackid'];
 
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         $ability->require_can('new', $moderatoragreement);
 
         $this->check_stage_permissions($this->params['stage_identifier']);
@@ -103,7 +103,7 @@ class moderations_controller extends controller_base {
         $moderation = new moderation($this->params['moderationid']);
         $this->check_stage_permissions($moderation->stageidentifier);
 
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         $ability->require_can('edit', $moderation);
 
         $urlparams = ['moderationid' => $this->params['moderationid']];
@@ -145,7 +145,7 @@ class moderations_controller extends controller_base {
         $url = $this->get_router()->get_path('new moderation', $pathparams, true);
         $PAGE->set_url($url);
 
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         $ability->require_can('new', $moderatoragreement);
 
         $form = new moderator_agreement_mform(null, ['moderation' => $moderatoragreement]);
@@ -178,7 +178,7 @@ class moderations_controller extends controller_base {
         $moderatoragreement = new moderation($this->params['moderationid']);
         $moderatoragreement->lasteditedby = $USER->id;
 
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         $ability->require_can('edit', $moderatoragreement);
 
         $this->check_stage_permissions($moderatoragreement->stageidentifier);
@@ -210,7 +210,7 @@ class moderations_controller extends controller_base {
 
         $moderation = new moderation($this->params['moderationid']);
 
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         $ability->require_can('show', $moderation);
 
         $renderer = $this->get_page_renderer();

--- a/classes/controllers/personal_deadlines_controller.php
+++ b/classes/controllers/personal_deadlines_controller.php
@@ -51,7 +51,7 @@ class personal_deadlines_controller extends controller_base {
         $courseworkpageurl = $this->get_path('coursework', ['coursework' => $this->coursework]);
 
         $urlparams = $this->set_default_current_deadline();
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         $ability->require_can('edit', $this->personaldeadline);
 
         $urlparams['allocatableid'] = (!is_array($urlparams['allocatableid']))

--- a/classes/controllers/plagiarism_flagging_controller.php
+++ b/classes/controllers/plagiarism_flagging_controller.php
@@ -67,7 +67,7 @@ class plagiarism_flagging_controller extends controller_base {
         $plagiarismflag->submissionid = $this->params['submissionid'];
         $plagiarismflag->courseworkid = $this->coursework->id;
 
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         $ability->require_can('new', $plagiarismflag);
 
         $urlparams = [];
@@ -91,7 +91,7 @@ class plagiarism_flagging_controller extends controller_base {
 
         $plagiarismflag = new plagiarism_flag($this->params['flagid']);
 
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         $ability->require_can('edit', $plagiarismflag);
 
         $urlparams = ['flagid' => $this->params['flagid']];
@@ -125,7 +125,7 @@ class plagiarism_flagging_controller extends controller_base {
         $url = $this->get_router()->get_path('new plagiarism flag', $pathparams, true);
         $PAGE->set_url($url);
 
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         $ability->require_can('new', $plagiarismflag);
 
         $form = new plagiarism_flagging_mform(null, ['submissionid' => $submission->id()]);
@@ -159,7 +159,7 @@ class plagiarism_flagging_controller extends controller_base {
         $plagiarismflag = new plagiarism_flag($this->params['flagid']);
         $plagiarismflag->lastmodifiedby = $USER->id;
 
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         $ability->require_can('edit', $plagiarismflag);
 
         $form = new plagiarism_flagging_mform(null, ['plagiarismflagid' => $this->params['flagid']]);

--- a/classes/controllers/submissions_controller.php
+++ b/classes/controllers/submissions_controller.php
@@ -79,16 +79,14 @@ class submissions_controller extends controller_base {
     protected function new_submission() {
         global $USER, $PAGE;
 
-        $user = user::find($USER);
-
         $submission = submission::build([
             'allocatableid' => $this->params['allocatableid'],
             'allocatabletype' => $this->params['allocatabletype'],
             'courseworkid' => $this->coursework->id,
-            'createdby' => $user->id()
+            'createdby' => $USER->id
         ]);
 
-        $ability = new ability($user, $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         if (!$ability->can('new', $submission)) {
             throw new access_denied($this->coursework);
         }
@@ -120,7 +118,7 @@ class submissions_controller extends controller_base {
 
         $submission = submission::find($this->params['submissionid']);
 
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         if (!$ability->can('edit', $submission)) {
             throw new access_denied($this->coursework);
         }
@@ -174,7 +172,7 @@ class submissions_controller extends controller_base {
             $submission->finalised = 1;
         }
 
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
 
         $this->exception_if_late($submission);
 
@@ -258,7 +256,7 @@ class submissions_controller extends controller_base {
 
         $submission = submission::find($this->params['submissionid']);
 
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         $this->exception_if_late($submission);
         if (!$ability->can('update', $submission)) {
             throw new access_denied($this->coursework, $ability->get_last_message());
@@ -317,7 +315,7 @@ class submissions_controller extends controller_base {
 
         $submission = submission::find($this->params['submissionid']);
 
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         if (!$ability->can('finalise', $submission)) {
             throw new access_denied($this->coursework);
         }

--- a/classes/export/csv/cells/agreedfeedback_cell.php
+++ b/classes/export/csv/cells/agreedfeedback_cell.php
@@ -98,7 +98,7 @@ class agreedfeedback_cell extends cell_base {
 
             $feedback = feedback::find($feedbackparams);
 
-            $ability = new ability(user::find($USER), $this->coursework);
+            $ability = new ability($USER->id, $this->coursework);
 
             // Does a feedback exist for this stage.
             if (empty($feedback)) {

--- a/classes/export/csv/cells/agreedgrade_cell.php
+++ b/classes/export/csv/cells/agreedgrade_cell.php
@@ -177,7 +177,7 @@ class agreedgrade_cell extends cell_base {
 
             $feedback = feedback::find($feedbackparams);
 
-            $ability = new ability(user::find($USER), $this->coursework);
+            $ability = new ability($USER->id, $this->coursework);
 
             // Does a feedback exist for this stage
             if (empty($feedback)) {

--- a/classes/export/csv/cells/assessorfeedback_cell.php
+++ b/classes/export/csv/cells/assessorfeedback_cell.php
@@ -44,7 +44,7 @@ class assessorfeedback_cell extends cell_base {
         $grade = $submission->get_assessor_feedback_by_stage($stageidentifier);
         if ($grade) {
             // check if user can see initial grades before all of them are completed
-            $ability = new ability(user::find($USER), $this->coursework);
+            $ability = new ability($USER->id, $this->coursework);
 
             $feedbackparams = [
                 'submissionid' => $submission->id,
@@ -116,7 +116,7 @@ class assessorfeedback_cell extends cell_base {
             ];
             $feedback = feedback::find($feedbackparams);
 
-            $ability = new ability(user::find($USER), $this->coursework);
+            $ability = new ability($USER->id, $this->coursework);
 
             // Does a feedback exist for this stage
             if (!empty($feedback)) {

--- a/classes/export/csv/cells/assessorgrade_cell.php
+++ b/classes/export/csv/cells/assessorgrade_cell.php
@@ -46,7 +46,7 @@ class assessorgrade_cell extends cell_base {
         $grade = $submission->get_assessor_feedback_by_stage($stageidentifier);
 
         // check if user can see initial grades before all of them are completed
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
 
         $feedbackparams = [
             'submissionid' => $submission->id,
@@ -200,7 +200,7 @@ class assessorgrade_cell extends cell_base {
             ];
             $feedback = feedback::find($feedbackparams);
 
-            $ability = new ability(user::find($USER), $this->coursework);
+            $ability = new ability($USER->id, $this->coursework);
 
             // Does a feedback exist for this stage
             if (!empty($feedback)) {

--- a/classes/export/csv/cells/feedbackcomments_cell.php
+++ b/classes/export/csv/cells/feedbackcomments_cell.php
@@ -78,11 +78,11 @@ class feedbackcomments_cell extends cell_base {
             }
 
             // Is the current user an assessor at any of this submissions grading stages or do they have administer grades
-            if (!$this->coursework->is_assessor($USER) && !has_capability('mod/coursework:administergrades', $PAGE->context)) {
+            if (!$this->coursework->is_assessor($USER->id) && !has_capability('mod/coursework:administergrades', $PAGE->context)) {
                 return get_string('nopermissiontogradesubmission', 'coursework');
             }
 
-            $ability = new ability(user::find($USER), $this->coursework);
+            $ability = new ability($USER->id, $this->coursework);
 
             $feedbackparams = [
                 'submissionid' => $submission->id,

--- a/classes/export/csv/cells/otherassessors_cell.php
+++ b/classes/export/csv/cells/otherassessors_cell.php
@@ -69,7 +69,7 @@ class otherassessors_cell extends cell_base {
                 if ($allocation && $allocation->assessorid == $USER->id) {
                     continue;
                 }
-                $ability = new ability(user::find($USER), $this->coursework);
+                $ability = new ability($USER->id, $this->coursework);
                 if ((($ability->can('show', $feedback) || has_capability('mod/coursework:addallocatedagreedgrade', $submission->get_coursework()->get_context())) &&
                     (!$submission->any_editable_feedback_exists() && count($submission->get_assessor_feedbacks()) <= $submission->max_number_of_feedbacks())) || is_siteadmin($USER->id)) {
 

--- a/classes/export/csv/cells/singlegrade_cell.php
+++ b/classes/export/csv/cells/singlegrade_cell.php
@@ -151,7 +151,7 @@ class singlegrade_cell extends cell_base {
             }
 
             // Is the current user an assessor at any of this submissions grading stages or do they have administer grades
-            if ($this->coursework->allocation_enabled() && !$this->coursework->is_assessor($USER) && !has_capability('mod/coursework:administergrades', $PAGE->context)) {
+            if ($this->coursework->allocation_enabled() && !$this->coursework->is_assessor($USER->id) && !has_capability('mod/coursework:administergrades', $PAGE->context)) {
                 return get_string('nopermissiontogradesubmission', 'coursework');
             }
 
@@ -175,7 +175,7 @@ class singlegrade_cell extends cell_base {
 
             }
 
-            $ability = new ability(user::find($USER), $this->coursework);
+            $ability = new ability($USER->id, $this->coursework);
 
             $feedbackparams = [
                 'submissionid' => $submission->id,

--- a/classes/export/grading_sheet.php
+++ b/classes/export/grading_sheet.php
@@ -48,7 +48,7 @@ class grading_sheet extends csv {
             return $submissions;
         }
 
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
 
         if (!has_capability('mod/coursework:administergrades', $PAGE->context)) {
 

--- a/classes/external/delete_extension.php
+++ b/classes/external/delete_extension.php
@@ -64,7 +64,7 @@ class delete_extension extends external_api {
             ];
         }
         $coursework = $extension->get_coursework();
-        $ability = $coursework ? new ability(user::find($USER), $coursework) : null;
+        $ability = $coursework ? new ability($USER->id, $coursework) : null;
         if ($ability && $ability->can('update', $extension) && $extension->can_be_deleted()) {
             $extension->delete();
             return [

--- a/classes/forms/deadline_extension_form.php
+++ b/classes/forms/deadline_extension_form.php
@@ -311,7 +311,7 @@ class deadline_extension_form extends dynamic_form {
     */
     protected function check_access_for_dynamic_submission(): void {
         global $USER;
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         if ($this->extension && $this->extension->extended_deadline) {
              $ability->require_can('edit', $this->extension);
         } else {
@@ -332,7 +332,7 @@ class deadline_extension_form extends dynamic_form {
         $warnings = [];
 
         // Code adapted from deadline_extensions_controller->update_deadline_extension().
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
         if (!$ability->can($this->extension->id ? 'update' : 'new', $this->extension)) {
             $errors[] = get_string('nopermissiongeneral', 'mod_coursework');
         }

--- a/classes/forms/personal_deadline_form.php
+++ b/classes/forms/personal_deadline_form.php
@@ -262,7 +262,7 @@ class personal_deadline_form extends dynamic_form {
             $datasource['allocatabletype'],
             $datasource['courseworkid'],
         );
-        $ability = new ability(user::find($USER), $this->get_coursework());
+        $ability = new ability($USER->id, $this->get_coursework());
         $deadline = personal_deadline::find_or_build($deadline);
         $deadline->courseworkid = $this->coursework->id();
         return $ability->can('edit', $deadline);

--- a/classes/forms/plagiarism_flagging_mform.php
+++ b/classes/forms/plagiarism_flagging_mform.php
@@ -201,7 +201,7 @@ class plagiarism_flagging_mform extends dynamic_form {
         $plagiarismflag->submissionid = $this->get_submission()->id();
         $plagiarismflag->courseworkid = $this->get_submission()->get_coursework()->id();
 
-        $ability = new ability(user::find($USER), $this->get_submission()->get_coursework());
+        $ability = new ability($USER->id, $this->get_submission()->get_coursework());
         return $ability->can('new', $plagiarismflag);
     }
 

--- a/classes/forms/student_submission_form.php
+++ b/classes/forms/student_submission_form.php
@@ -298,7 +298,7 @@ class student_submission_form extends moodleform {
     protected function add_submit_buttons_to_form() {
         global $USER;
 
-        $ability = new ability(user::find($USER), $this->get_coursework());
+        $ability = new ability($USER->id, $this->get_coursework());
 
         $buttonarray = [];
         // If submitting on behalf of someone else, we want to make sure that we don't have people leaving it in a draft

--- a/classes/framework/ability.php
+++ b/classes/framework/ability.php
@@ -22,6 +22,7 @@
 
 namespace mod_coursework\framework;
 use mod_coursework\ability\rule;
+use mod_coursework\models\user;
 
 /**
  * This class provides a central point where all of the can/cannot decisions are stored.
@@ -42,9 +43,15 @@ use mod_coursework\ability\rule;
 abstract class ability {
 
     /**
-     * @var \stdClass;
+     * @var ?user $user;
      */
-    protected $user;
+    protected ?user $user = null;
+
+    /**
+     * The user ID.
+     * @var int $userid
+     */
+    protected int $userid;
 
     /**
      * @var string
@@ -61,8 +68,8 @@ abstract class ability {
      *
      * @param $user
      */
-    public function __construct($user) {
-        $this->user = $user;
+    public function __construct(int $userid) {
+        $this->userid = $userid;
     }
 
     /**
@@ -165,6 +172,9 @@ abstract class ability {
      * @return table_base|\stdClass
      */
     protected function get_user() {
+        if ($this->user === null) {
+            $this->user = user::find($this->userid);
+        }
         return $this->user;
     }
 

--- a/classes/framework/table_base.php
+++ b/classes/framework/table_base.php
@@ -24,8 +24,6 @@ namespace mod_coursework\framework;
 
 use stdClass;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * This forms the base class for other classes that represent database table objects using the Active Record pattern.
  *

--- a/classes/grading_report.php
+++ b/classes/grading_report.php
@@ -25,10 +25,11 @@ namespace mod_coursework;
 use mod_coursework\models\allocation;
 use mod_coursework\models\course_module;
 use mod_coursework\models\coursework;
+use mod_coursework\models\deadline_extension;
+use mod_coursework\models\personal_deadline;
 use mod_coursework\models\feedback;
 use mod_coursework\models\module;
 use mod_coursework\models\submission;
-use mod_coursework\models\user;
 use mod_coursework\render_helpers\grading_report\cells\cell_interface;
 use mod_coursework\render_helpers\grading_report\sub_rows\sub_rows_interface;
 
@@ -351,6 +352,10 @@ class grading_report {
             $options = $this->options;
 
             $participants = $this->coursework->get_allocatables();
+            $extensions = $this->coursework->extensions_enabled()
+                ? deadline_extension::get_all_for_coursework($this->coursework->id) : [];
+            $personaldeadlines = $this->coursework->personal_deadlines_enabled()
+                ? personal_deadline::get_all_for_coursework($this->coursework->id) : [];
 
             // Make tablerow objects so we can use the methods to check permissions and set things.
             $rows = [];
@@ -375,7 +380,33 @@ class grading_report {
                     }
                 }
 
-                $row = new $rowclass($this->coursework, $participant);
+                // To save multiple queries to DB for extensions and deadlines, add them here.
+                $extension = array_filter(
+                    $extensions,
+                    function ($ext) use ($participant) {
+                        return $participant->id() == $ext->allocatableid
+                            && $participant->type() == $ext->allocatabletype;
+                    }
+                );
+                $extension = array_pop($extension);
+
+                $personaldeadline = array_filter(
+                    $personaldeadlines,
+                    function ($ext) use ($participant) {
+                        return $participant->id() == $ext->allocatableid
+                            && $participant->type() == $ext->allocatabletype;
+                    }
+                );
+                $personaldeadline = array_pop($personaldeadline);
+
+                // New grading_table_row_base.
+                $row = new $rowclass(
+                    $this->coursework,
+                    $participant,
+                    $extension ? deadline_extension::find($extension, false) : null,
+                    $personaldeadline ? personal_deadline::find($personaldeadline, false) : null,
+                    $personaldeadline,
+                );
 
                 // Now, we skip the ones who should not be visible on this page.
                 $canshow = $ability->can('show', $row);

--- a/classes/grading_report.php
+++ b/classes/grading_report.php
@@ -32,8 +32,6 @@ use mod_coursework\models\user;
 use mod_coursework\render_helpers\grading_report\cells\cell_interface;
 use mod_coursework\render_helpers\grading_report\sub_rows\sub_rows_interface;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Renderable component containing all the data needed to display the grading report
  */
@@ -356,8 +354,9 @@ class grading_report {
 
             // Make tablerow objects so we can use the methods to check permissions and set things.
             $rows = [];
-            $rowclass = $this->coursework->has_multiple_markers() ? 'mod_coursework\grading_table_row_multi' : 'mod_coursework\grading_table_row_single';
-            $ability = new ability(user::find($USER, false), $this->get_coursework());
+            $rowclass = $this->coursework->has_multiple_markers()
+                ? 'mod_coursework\grading_table_row_multi' : 'mod_coursework\grading_table_row_single';
+            $ability = new ability($USER->id, $this->get_coursework());
 
             $participantsfound = 0;
 
@@ -388,7 +387,6 @@ class grading_report {
                     unset($participants[$key]);
                     continue;
                 }
-
                 $rows[$participant->id()] = $row;
                 $participantsfound++;
                 if (!empty($rowcount) && $participantsfound >= $rowcount) {
@@ -396,7 +394,6 @@ class grading_report {
                 }
 
             }
-
             // Sort the rows.
             $methodname = 'sort_by_' . $options['sortby'];
             if (method_exists($this, $methodname)) {

--- a/classes/models/coursework.php
+++ b/classes/models/coursework.php
@@ -855,12 +855,12 @@ class coursework extends table_base {
     }
 
     /**
-     * @param user $user
+     * @param int $userid
      * @return bool
      */
-    public function is_assessor($user) {
+    public function is_assessor(int $userid) {
         foreach ($this->marking_stages() as $stage) {
-            if ($stage->user_is_assessor($user)) {
+            if ($stage->user_is_assessor($userid)) {
                 return true;
             }
         }
@@ -958,7 +958,7 @@ class coursework extends table_base {
         global $CFG, $DB, $USER;
 
         $context = \context_module::instance($this->get_coursemodule_id());
-        $ability = new ability(user::find($USER), $this);
+        $ability = new ability($USER->id, $this);
 
         $submissions = $DB->get_records('coursework_submissions',
                                         ['courseworkid' => $this->id, 'finalised' => 1]);

--- a/classes/models/deadline_extension.php
+++ b/classes/models/deadline_extension.php
@@ -276,6 +276,8 @@ class deadline_extension extends table_base {
     /**
      * Get extension for a particular allocatable from the database.
      * @param int $courseworkid
+     * @param int $allocatableid
+     * @param string $allocatabletype
      * @return ?self
      */
     public static function get_for_allocatable(int $courseworkid, int $allocatableid, string $allocatabletype): ?self {

--- a/classes/models/deadline_extension.php
+++ b/classes/models/deadline_extension.php
@@ -262,4 +262,28 @@ class deadline_extension extends table_base {
         }
         $event->trigger();
     }
+
+    /**
+     * Get all extensions for a particular coursework from the database.
+     * @param int $courseworkid
+     * @return array
+     */
+    public static function get_all_for_coursework(int $courseworkid): array {
+        global $DB;
+        return $DB->get_records(self::$tablename, ['courseworkid' => $courseworkid]);
+    }
+
+    /**
+     * Get extension for a particular allocatable from the database.
+     * @param int $courseworkid
+     * @return ?self
+     */
+    public static function get_for_allocatable(int $courseworkid, int $allocatableid, string $allocatabletype): ?self {
+        global $DB;
+        $record = $DB->get_record(
+            self::$tablename,
+            ['courseworkid' => $courseworkid, 'allocatableid' => $allocatableid, 'allocatabletype' => $allocatabletype]
+        );
+        return $record ? new self($record) : null;
+    }
 }

--- a/classes/models/feedback.php
+++ b/classes/models/feedback.php
@@ -240,22 +240,6 @@ class feedback extends table_base {
     public function get_feedbacks_assessorid() {
         return $this->assessorid;
     }
-    /**
-     * Gets the HTML user picture for the assessor.
-     *
-     * @return \core\output\user_picture
-     */
-    public function get_assessor_user_picture() {
-        global $DB;
-
-        if ($user = $DB->get_record('user', ['id' => $this->assessorid])) {
-            $userpicture = new \core\output\user_picture($user);
-            $userpicture->size = 100;
-            return $userpicture;
-        }
-
-        return '';
-    }
 
     /**
      * Chained getter for loose coupling.

--- a/classes/models/group.php
+++ b/classes/models/group.php
@@ -72,13 +72,6 @@ class group extends table_base implements allocatable, moderatable {
     }
 
     /**
-     * @return string
-     */
-    public function picture() {
-        return print_group_picture($this, $this->courseid);
-    }
-
-    /**
      * @return user[]
      */
     public function get_members($context, $cm) {

--- a/classes/models/null_user.php
+++ b/classes/models/null_user.php
@@ -35,13 +35,6 @@ class null_user implements \mod_coursework\allocation\allocatable {
     }
 
     /**
-     * @return string
-     */
-    public function picture() {
-        return '';
-    }
-
-    /**
      * @return int
      */
     public function id() {

--- a/classes/models/personal_deadline.php
+++ b/classes/models/personal_deadline.php
@@ -204,6 +204,8 @@ class personal_deadline extends table_base {
     /**
      * Get deadline for a particular allocatable from the database.
      * @param int $courseworkid
+     * @param int $allocatableid
+     * @param string $allocatabletype
      * @return ?self
      */
     public static function get_for_allocatable(int $courseworkid, int $allocatableid, string $allocatabletype): ?self {

--- a/classes/models/personal_deadline.php
+++ b/classes/models/personal_deadline.php
@@ -76,7 +76,7 @@ class personal_deadline extends table_base {
                         'allocatableid' => $this->allocatableid,
                         'allocatabletype' => $this->allocatabletype];
 
-        return   deadline_extension::find($params);
+        return deadline_extension::find($params);
     }
 
     /**
@@ -189,5 +189,29 @@ class personal_deadline extends table_base {
                 throw new invalid_parameter_exception("Unexpected event type '$eventtype'");
         }
         $event->trigger();
+    }
+
+    /**
+     * Get all personal deadlines for a particular coursework from the database.
+     * @param int $courseworkid
+     * @return array
+     */
+    public static function get_all_for_coursework(int $courseworkid): array {
+        global $DB;
+        return $DB->get_records(self::$tablename, ['courseworkid' => $courseworkid]);
+    }
+
+    /**
+     * Get deadline for a particular allocatable from the database.
+     * @param int $courseworkid
+     * @return ?self
+     */
+    public static function get_for_allocatable(int $courseworkid, int $allocatableid, string $allocatabletype): ?self {
+        global $DB;
+        $record = $DB->get_record(
+            self::$tablename,
+            ['courseworkid' => $courseworkid, 'allocatableid' => $allocatableid, 'allocatabletype' => $allocatabletype]
+        );
+        return $record ? new self($record) : null;
     }
 }

--- a/classes/models/user.php
+++ b/classes/models/user.php
@@ -147,7 +147,7 @@ class user extends table_base implements allocatable, moderatable {
     /**
      * Get user picture URL as string without going to database.
      * @param int|null $usercontextid
-     * @param int|null $rev
+     * @param int|null $rev mdl_user.picture value (falsey = no image, +ve value = revision num to avoid browser caching problems).
      * @return string
      */
     public static function get_picture_url_from_context_id(?int $usercontextid, ?int $rev): string {
@@ -266,23 +266,15 @@ class user extends table_base implements allocatable, moderatable {
      */
     public static function get_user_picture_context_ids(int $courseid): array {
         global $DB;
-        $ctxids = [];
-        $rs = $DB->get_recordset_sql(
+        return $DB->get_records_sql_menu(
         "SELECT u.id, ctx.id as ctxid
-                FROM {user} u
-                JOIN {context} ctx on ctx.instanceid = u.id AND ctx.contextlevel = ?
-                JOIN {user_enrolments} ue ON ue.userid = u.id
-                JOIN {enrol} e ON ue.enrolid = e.id AND e.courseid = ?
-                WHERE u.picture != 0",
+            FROM {user} u
+            JOIN {context} ctx on ctx.instanceid = u.id AND ctx.contextlevel = ?
+            JOIN {user_enrolments} ue ON ue.userid = u.id
+            JOIN {enrol} e ON ue.enrolid = e.id AND e.courseid = ?
+            WHERE u.picture <> 0",
             [CONTEXT_USER, $courseid]
         );
-        if ($rs->valid()) {
-            foreach($rs as $r) {
-                $ctxids[$r->id] = $r->ctxid;
-            }
-            $rs->close();
-        }
-        return $ctxids;
     }
 
 }

--- a/classes/models/user.php
+++ b/classes/models/user.php
@@ -62,7 +62,22 @@ class user extends table_base implements allocatable, moderatable {
      * @return string
      */
     public function name() {
-        return fullname($this->get_raw_record());
+        // If we already have properties to get the name without going to database, use them.
+        $data = new \stdClass;
+        $hasallfields = true;
+        foreach (\core_user\fields::get_name_fields() as $field) {
+            if ($this->$field ?? false) {
+                $data->field = $this->$field;
+            } else {
+                $hasallfields = false;
+                break;
+            }
+        }
+        if ($hasallfields) {
+            return \core_user::get_fullname($data);
+        }
+
+        return \core_user::get_fullname($this->get_raw_record());
     }
 
     /**
@@ -75,27 +90,8 @@ class user extends table_base implements allocatable, moderatable {
     /**
      * @return string
      */
-    public function picture() {
-        global $OUTPUT;
-
-        return $OUTPUT->user_picture($this->get_raw_record());
-    }
-
-    /**
-     * @param bool $withpicture
-     * @return string
-     */
-    public function profile_link($withpicture = false) {
-        global $OUTPUT;
-
-        $output = '';
-        if ($withpicture) {
-            $output .= $OUTPUT->user_picture($this->get_raw_record(), ['link' => false]);
-            $output .= ' ';
-        }
-        $output .= ' ' . $this->name();
-
-        return \html_writer::link(new \moodle_url('/user/view.php', ['id' => $this->id()]), $output, ['data-assessorid' => $this->id()]);
+    public function profile_link() {
+        return \html_writer::link(new \moodle_url('/user/view.php', ['id' => $this->id()]), $this->name(), ['data-assessorid' => $this->id()]);
     }
 
     /**
@@ -145,6 +141,33 @@ class user extends table_base implements allocatable, moderatable {
         $userpicture = new \core\output\user_picture($this->get_raw_record());
         $userpicture->size = $size;
         return $userpicture->get_url($PAGE)->out(false);
+    }
+
+    /**
+     * Get user picture URL as string without going to database.
+     * @param int|null $usercontextid
+     * @param int|null $rev
+     * @return string
+     */
+    public static function get_picture_url_from_context_id(?int $usercontextid, ?int $rev): string {
+        global $PAGE, $OUTPUT;
+        // On teacher grading page, we avoid using \core\output\user_picture.
+        // We don't need the extra fields and it results in additional DB queries.
+        if ($usercontextid && $rev) {
+            $url = \moodle_url::make_pluginfile_url(
+                $usercontextid,
+                'user',
+                'icon',
+                null,
+                "/" . $PAGE->theme->name . "/",
+                "f1",
+                false,
+                false
+            );
+            $url->param('rev', $rev);
+            return $url->out(false);
+        }
+        return $OUTPUT->image_url('u/f1')->out(false);
     }
 
     /**
@@ -233,6 +256,32 @@ class user extends table_base implements allocatable, moderatable {
             self::$pool['id'][$id] = new self($user);
         }
         return self::$pool['id'][$id];
+    }
+
+    /**
+     * To save multiple queries to get user picture data, get relevant user context IDs for course in one hit.
+     * @param int $courseid
+     * @return array
+     */
+    public static function get_user_picture_context_ids(int $courseid): array {
+        global $DB;
+        $ctxids = [];
+        $rs = $DB->get_recordset_sql(
+        "SELECT u.id, ctx.id as ctxid
+                FROM {user} u
+                JOIN {context} ctx on ctx.instanceid = u.id AND ctx.contextlevel = ?
+                JOIN {user_enrolments} ue ON ue.userid = u.id
+                JOIN {enrol} e ON ue.enrolid = e.id AND e.courseid = ?
+                WHERE u.picture != 0",
+            [CONTEXT_USER, $courseid]
+        );
+        if ($rs->valid()) {
+            foreach($rs as $r) {
+                $ctxids[$r->id] = $r->ctxid;
+            }
+            $rs->close();
+        }
+        return $ctxids;
     }
 
 }

--- a/classes/models/user.php
+++ b/classes/models/user.php
@@ -59,15 +59,16 @@ class user extends table_base implements allocatable, moderatable {
     }
 
     /**
+     * Get the user's full name.
      * @return string
      */
-    public function name() {
+    public function name(): string {
         // If we already have properties to get the name without going to database, use them.
         $data = new \stdClass;
         $hasallfields = true;
         foreach (\core_user\fields::get_name_fields() as $field) {
             if ($this->$field ?? false) {
-                $data->field = $this->$field;
+                $data->$field = $this->$field;
             } else {
                 $hasallfields = false;
                 break;

--- a/classes/personal_deadline/allocatable.php
+++ b/classes/personal_deadline/allocatable.php
@@ -50,11 +50,6 @@ interface allocatable {
     public function type();
 
     /**
-     * @return string
-     */
-    public function picture();
-
-    /**
      * @param bool $withpicture
      * @return string
      */

--- a/classes/render_helpers/grading_report/cells/_user_cell.php
+++ b/classes/render_helpers/grading_report/cells/_user_cell.php
@@ -39,25 +39,7 @@ class user_cell extends cell_base implements allocatable_cell {
      * @return string
      */
     public function get_table_cell($rowobject) {
-        global $OUTPUT, $PAGE;
-
         $content = '';
-
-        /**
-         * @var user $user
-         */
-        $user = $rowobject->get_allocatable();
-
-        /*      if ($rowobject->can_view_username()) {
-            $content .= $OUTPUT->user_picture($user->get_raw_record());
-        } else {
-            $renderer = $PAGE->get_renderer('core');
-            // Just output the image for an anonymous user.
-            $defaulturl = $renderer->pix_url('u/f2'); // Default image.
-            $attributes = array('src' => $defaulturl);
-            $content .= html_writer::empty_tag('img', $attributes);
-        } */
-        // TODO CSS for the space!!
         $content .= ' ' . $rowobject->get_user_name(true);
 
         return $this->get_new_cell_with_class($content);

--- a/classes/render_helpers/grading_report/cells/_user_cell.php
+++ b/classes/render_helpers/grading_report/cells/_user_cell.php
@@ -39,10 +39,7 @@ class user_cell extends cell_base implements allocatable_cell {
      * @return string
      */
     public function get_table_cell($rowobject) {
-        $content = '';
-        $content .= ' ' . $rowobject->get_user_name(true);
-
-        return $this->get_new_cell_with_class($content);
+        return $this->get_new_cell_with_class(' ' . $rowobject->get_user_name(true));
     }
 
     /**

--- a/classes/render_helpers/grading_report/cells/grade_for_gradebook_cell.php
+++ b/classes/render_helpers/grading_report/cells/grade_for_gradebook_cell.php
@@ -41,7 +41,7 @@ class grade_for_gradebook_cell extends cell_base {
         global $USER;
 
         $content = '';
-        $ability = new ability(user::find($USER), $rowobject->get_coursework());
+        $ability = new ability($USER->id, $rowobject->get_coursework());
         $judge = new grade_judge($this->coursework);
         if ($ability->can('show', $judge->get_feedback_that_is_promoted_to_gradebook($rowobject->get_submission())) && !$rowobject->get_submission()->editable_final_feedback_exist()) {
             $grade = $judge->get_grade_capped_by_submission_time($rowobject->get_submission());

--- a/classes/render_helpers/grading_report/cells/group_cell.php
+++ b/classes/render_helpers/grading_report/cells/group_cell.php
@@ -100,7 +100,7 @@ class group_cell extends cell_base implements allocatable_cell {
         if ($this->coursework->blindmarking_enabled() && !has_capability('mod/coursework:viewanonymous', $this->coursework->get_context()) && !$rowobject->is_published()) {
             $text .= 'Hidden';
         } else {
-            $text .= $groupmember->profile_link(false) . ' ('. $groupmember->email.')';
+            $text .= $groupmember->profile_link() . ' ('. $groupmember->email.')';
         }
         $text .= '</option>';
         return $text;

--- a/classes/render_helpers/grading_report/cells/moderation_agreement_cell.php
+++ b/classes/render_helpers/grading_report/cells/moderation_agreement_cell.php
@@ -61,7 +61,7 @@ class moderation_agreement_cell extends cell_base {
     public function get_table_cell($rowobject) {
         global $USER;
 
-        $ability = new ability(user::find($USER), $rowobject->get_coursework());
+        $ability = new ability($USER->id, $rowobject->get_coursework());
 
         $content = '';
         $moderation = '';

--- a/classes/render_helpers/grading_report/cells/moderation_cell.php
+++ b/classes/render_helpers/grading_report/cells/moderation_cell.php
@@ -62,7 +62,7 @@ class moderation_cell extends cell_base {
             $content .= $this->add_existing_moderator_feedback_details_to_cell($rowobject);
         }
 
-        $ability = new ability(user::find($USER), $rowobject->get_coursework());
+        $ability = new ability($USER->id, $rowobject->get_coursework());
         $existingfeedback = $this->stage->get_feedback_for_allocatable($rowobject->get_allocatable());
         $newfeedback = feedback::build([
             'submissionid' => $rowobject->get_submission_id(),

--- a/classes/render_helpers/grading_report/cells/multiple_agreed_grade_cell.php
+++ b/classes/render_helpers/grading_report/cells/multiple_agreed_grade_cell.php
@@ -70,7 +70,7 @@ class multiple_agreed_grade_cell extends cell_base {
             $content = get_string('singlemarker', 'coursework');
             return $content;
         }
-        $ability = new ability(user::find($USER, false), $rowobject->get_coursework());
+        $ability = new ability($USER->id, $rowobject->get_coursework());
 
         $content = '';
 

--- a/classes/render_helpers/grading_report/cells/personal_deadline_cell.php
+++ b/classes/render_helpers/grading_report/cells/personal_deadline_cell.php
@@ -57,7 +57,7 @@ class personal_deadline_cell extends cell_base {
         }
         $date = userdate($deadline, '%a, %d %b %Y, %H:%M');
         $content .= '<div class="content_personal_deadline">'.$date.'</div>';
-        $ability = new ability(user::find($USER, false), $rowobject->get_coursework());
+        $ability = new ability($USER->id, $rowobject->get_coursework());
         $class = 'edit_personal_deadline';
         if (!$ability->can('edit', $personaldeadline)) {
             $class .= ' display-none';

--- a/classes/render_helpers/grading_report/cells/plagiarism_cell.php
+++ b/classes/render_helpers/grading_report/cells/plagiarism_cell.php
@@ -44,7 +44,7 @@ class plagiarism_cell extends cell_base {
         global $USER;
 
         $content = '';
-        $ability = new ability(user::find($USER), $rowobject->get_coursework());
+        $ability = new ability($USER->id, $rowobject->get_coursework());
 
         if ($rowobject->has_submission() && $ability->can('show', $rowobject->get_submission())) {
             // The files and the form to resubmit them.

--- a/classes/render_helpers/grading_report/cells/plagiarism_flag_cell.php
+++ b/classes/render_helpers/grading_report/cells/plagiarism_flag_cell.php
@@ -47,7 +47,7 @@ class plagiarism_flag_cell extends cell_base {
         global $USER;
 
         $content = '';
-        $ability = new ability(user::find($USER), $rowobject->get_coursework());
+        $ability = new ability($USER->id, $rowobject->get_coursework());
 
         if ($rowobject->has_submission() && $rowobject->get_submission()->finalised) {
             $plagiarismflagparams = [

--- a/classes/render_helpers/grading_report/cells/single_assessor_feedback_cell.php
+++ b/classes/render_helpers/grading_report/cells/single_assessor_feedback_cell.php
@@ -75,7 +75,7 @@ class single_assessor_feedback_cell extends cell_base {
         // Single:
         // Feedback column.
 
-        $ability = new ability(user::find($USER), $rowobject->get_coursework());
+        $ability = new ability($USER->id, $rowobject->get_coursework());
 
         $content = '';
         $submission = $rowobject->get_submission();
@@ -84,7 +84,7 @@ class single_assessor_feedback_cell extends cell_base {
         // Add new feedback
         if ($rowobject->has_submission() &&
             $rowobject->get_submission()->ready_to_grade() &&
-            ($this->stage->user_is_assessor($USER) ||
+            ($this->stage->user_is_assessor($USER->id) ||
                 has_capability('mod/coursework:administergrades', $this->coursework->get_context()))) {
 
             $feedbackparams = [

--- a/classes/render_helpers/grading_report/cells/submission_cell.php
+++ b/classes/render_helpers/grading_report/cells/submission_cell.php
@@ -47,7 +47,7 @@ class submission_cell extends cell_base {
 
         $content = '';
 
-        $ability = new ability(user::find($USER), $this->coursework);
+        $ability = new ability($USER->id, $this->coursework);
 
         if ($rowobject->has_submission() && $ability->can('show', $rowobject->get_submission())) {
             // The files and the form to resubmit them.
@@ -68,7 +68,7 @@ class submission_cell extends cell_base {
             $content .= $ability->get_last_message();
         }
 
-        $ability = new ability(user::find($USER), $rowobject->get_coursework());
+        $ability = new ability($USER->id, $rowobject->get_coursework());
 
         $submissiononbehalfofallocatable = submission::build([
                                                                      'allocatableid' => $rowobject->get_allocatable()

--- a/classes/render_helpers/grading_report/cells/time_submitted_cell.php
+++ b/classes/render_helpers/grading_report/cells/time_submitted_cell.php
@@ -115,7 +115,7 @@ class time_submitted_cell extends cell_base {
         ];
 
         $extension = deadline_extension::find_or_build($newextensionparams);
-        $ability = new ability(user::find($USER), $rowobject->get_coursework());
+        $ability = new ability($USER->id, $rowobject->get_coursework());
 
         if ($extension->persisted()) {
             $content .= 'Extension: </br>'.userdate($extension->extended_deadline, '%a, %d %b %Y, %H:%M');

--- a/classes/render_helpers/grading_report/cells/user_cell.php
+++ b/classes/render_helpers/grading_report/cells/user_cell.php
@@ -39,9 +39,8 @@ class user_cell extends cell_base implements allocatable_cell {
      * @return string
      */
     public function get_table_cell($rowobject) {
-        $content = '';
-        $content .= ' ' . $rowobject->get_user_name(true);
-        $content .= "<br>".$rowobject->get_email();
+        $content = ' ' . $rowobject->get_user_name(true)
+            . "<br>" . $rowobject->get_email();
         return $this->get_new_cell_with_class($content);
     }
 

--- a/classes/render_helpers/grading_report/cells/user_cell.php
+++ b/classes/render_helpers/grading_report/cells/user_cell.php
@@ -39,34 +39,9 @@ class user_cell extends cell_base implements allocatable_cell {
      * @return string
      */
     public function get_table_cell($rowobject) {
-        global $OUTPUT, $PAGE;
-
         $content = '';
-
-        /*      if ($rowobject->can_view_username()) {
-            $content .= $OUTPUT->user_picture($user->get_raw_record());
-        } else {
-            $renderer = $PAGE->get_renderer('core');
-            // Just output the image for an anonymous user.
-            $defaulturl = $renderer->pix_url('u/f2'); // Default image.
-            $attributes = array('src' => $defaulturl);
-            $content .= html_writer::empty_tag('img', $attributes);
-        } */
-        // TODO CSS for the space!!
         $content .= ' ' . $rowobject->get_user_name(true);
         $content .= "<br>".$rowobject->get_email();
-        $user = $rowobject->get_allocatable();
-        /*
-        $candidatenumber = $user->candidate_number();
-
-        if (!empty($candidatenumber)) {
-
-            $content  .= '<br /> ('.$candidatenumber.')';
-
-        }
-
-        */
-
         return $this->get_new_cell_with_class($content);
     }
 

--- a/classes/render_helpers/grading_report/data/actions_cell_data.php
+++ b/classes/render_helpers/grading_report/data/actions_cell_data.php
@@ -275,8 +275,8 @@ class actions_cell_data extends cell_data_base {
                     $personaldeadlineobject->personal_deadline, get_string('strftimedaydatetime', 'langconfig'), fixday: false
                 ),
                 'exists' => $personaldeadlineobject->personal_deadline > 0 ? 1 : 0,
-                // Careful when to allow edits (e.g. edit blocked if extension exists for this user).
-                'is_editable' => true,
+                // Disable deadline edit link if extension also exists (as ability class will throw error if edit attempted).
+                'is_editable' => !$rowsbase->get_extension(),
                 'deadlineid' => $personaldeadlineobject->id,
             ];
         } else {

--- a/classes/render_helpers/grading_report/data/actions_cell_data.php
+++ b/classes/render_helpers/grading_report/data/actions_cell_data.php
@@ -111,7 +111,8 @@ class actions_cell_data extends cell_data_base {
 
             $data->extension->show = $canedit || $cannew;
             $data->extension->class = $extension ? 'edit_deadline_extension' : 'new_deadline_extension';
-            $data->extension->stdname = $rowsbase->get_user_name();
+            $data->extension->stdname = $rowsbase->can_see_user_name()
+                ? $rowsbase->get_allocatable()->name() : get_string('hidden', 'mod_coursework');
             $data->extension->url = $extension ? router::instance()->get_path('edit deadline extension', ['id' => $extension->id]) :
                 htmlspecialchars_decode(router::instance()->get_path('new deadline extension', $extensionparams));
         }
@@ -170,7 +171,8 @@ class actions_cell_data extends cell_data_base {
             $data->finalise = new stdClass();
             $data->finalise->url = router::instance()
                 ->get_path('finalise submission', ['submission' => $rowsbase->get_submission()], false, false);
-            $data->finalise->studentname = $rowsbase->get_user_name();
+            $data->finalise->studentname = $rowsbase->can_see_user_name()
+                ? $rowsbase->get_allocatable()->name() : get_string('hidden', 'mod_coursework');
         }
     }
 
@@ -193,7 +195,8 @@ class actions_cell_data extends cell_data_base {
                 ]);
             $data->unfinalise = new stdClass();
             $data->unfinalise->url = $url->out(false);
-            $data->unfinalise->studentname = $rowsbase->get_user_name();
+            $data->unfinalise->studentname = $rowsbase->can_see_user_name()
+                ? $rowsbase->get_allocatable()->name() : get_string('hidden', 'mod_coursework');
         }
     }
 

--- a/classes/render_helpers/grading_report/data/cell_data_base.php
+++ b/classes/render_helpers/grading_report/data/cell_data_base.php
@@ -55,7 +55,7 @@ abstract class cell_data_base implements cell_data_interface {
         global $USER;
 
         $this->coursework = $coursework;
-        $this->ability = new ability(user::find($USER), $this->coursework);
+        $this->ability = new ability($USER->id, $this->coursework);
         $this->clock = di::get(clock::class);
     }
 

--- a/classes/render_helpers/grading_report/data/student_cell_data.php
+++ b/classes/render_helpers/grading_report/data/student_cell_data.php
@@ -109,15 +109,17 @@ class student_cell_data extends cell_data_base {
                 'id' => '',
                 'name' => $this->get_candidate_or_fallback($rowsbase->get_allocatable_id(), 'hidden'),
                 'url' => '',
-                'picture' => ''
             ];
         }
-
         return (object)[
             'id' => $rowsbase->get_allocatable_id(),
-            'name' => $this->get_enhanced_name_with_candidate_number($user->id(), $rowsbase->get_user_name()),
+            'name' => $this->get_enhanced_name_with_candidate_number(
+                $user->id(),
+                $rowsbase->can_see_user_name()
+                    ? $rowsbase->get_allocatable()->name()
+                    : get_string('hidden', 'mod_coursework')
+            ),
             'url' => $user->get_user_profile_url(),
-            'picture' => $user->get_user_picture_url()
         ];
     }
 

--- a/classes/render_helpers/grading_report/data/submission_cell_data.php
+++ b/classes/render_helpers/grading_report/data/submission_cell_data.php
@@ -182,7 +182,7 @@ class submission_cell_data extends cell_data_base {
             return;
         }
         // User does not have permission to view extension.
-        if (!$this->ability->can('show', deadline_extension::find(['id' => $extension->id]))) {
+        if (!$this->ability->can('show', $extension)) {
             return;
         }
         $data->extensiongranted = true;

--- a/classes/render_helpers/grading_report/sub_rows/multi_marker_feedback_sub_rows.php
+++ b/classes/render_helpers/grading_report/sub_rows/multi_marker_feedback_sub_rows.php
@@ -81,7 +81,7 @@ class multi_marker_feedback_sub_rows implements sub_rows_interface {
         global $USER;
 
         if (empty($ability)) {
-            $ability = new ability(user::find($USER), $coursework);
+            $ability = new ability($USER->id, $coursework);
         }
         $needsgradedby = $coursework->allocation_enabled() && $feedbackrow->has_feedback()
             && $feedbackrow->get_graded_by() != $feedbackrow->get_assessor();
@@ -106,7 +106,7 @@ class multi_marker_feedback_sub_rows implements sub_rows_interface {
         global $USER, $PAGE;
 
         $coursework = $assessorfeedbacktable->get_coursework();
-        $ability = new ability(user::find($USER, false), $coursework);
+        $ability = new ability($USER->id, $coursework);
         $feedbackrows = $assessorfeedbacktable->get_renderable_feedback_rows();
 
         $allocatable = $assessorfeedbacktable->get_allocatable();

--- a/classes/renderers/grading_report_renderer.php
+++ b/classes/renderers/grading_report_renderer.php
@@ -23,7 +23,8 @@
 namespace mod_coursework\renderers;
 
 use mod_coursework\ability;
-use mod_coursework\allocation\allocatable;
+use mod_coursework\models\deadline_extension;
+use mod_coursework\models\personal_deadline;
 use mod_coursework\grading_report;
 use mod_coursework\grading_table_row_base;
 use mod_coursework\models\coursework;
@@ -71,7 +72,8 @@ class grading_report_renderer extends \core\output\plugin_renderer_base {
 
             // Add the user picture.
             $participantcontextid = $participantcontextids[$rowobject->get_allocatable()->id()] ?? null;
-            $trdata->submissiontype->user->picture = user::get_picture_url_from_context_id($participantcontextid, $rowobject->get_allocatable()->picture);
+            $trdata->submissiontype->user->picture =
+                user::get_picture_url_from_context_id($participantcontextid, $rowobject->get_allocatable()->picture);
 
             // Add allocated markers for data-marker and dropdown filter.
             if (!empty($trdata->markers)) {
@@ -148,22 +150,29 @@ class grading_report_renderer extends \core\output\plugin_renderer_base {
     /**
      * Export the data for a single table row to make it accessible from JS.
      * Enables a table row to be re-rendered from JS when updated via modal form.
-     * @param int $alloctableid
+     * @param int $allocatableid
      * @param string $allocatabletype
      * @return ?object
      */
-    public static function export_one_row_data(coursework $coursework, int $alloctableid, string $allocatabletype): ?object {
+    public static function export_one_row_data(coursework $coursework, int $allocatableid, string $allocatabletype): ?object {
         global $USER;
         $classname = "\\mod_coursework\\models\\$allocatabletype";
-        $alloctable = $classname::get_object($alloctableid);
-        if (!$alloctable) {
+        $allocatable = $classname::get_object($allocatableid);
+        if (!$allocatable) {
             return null;
         }
         $rowclass = $coursework->has_multiple_markers()
             ? 'mod_coursework\grading_table_row_multi'
             : 'mod_coursework\grading_table_row_single';
         $ability = new ability($USER->id, $coursework);
-        $row = new $rowclass($coursework, $alloctable);
+
+        // New grading_table_row_base.
+        $row = new $rowclass(
+            $coursework,
+            $allocatable,
+            deadline_extension::get_for_allocatable($coursework->id, $allocatableid, $allocatabletype),
+            personal_deadline::get_for_allocatable($coursework->id, $allocatableid, $allocatabletype),
+        );
         if (!$ability->can('show', $row)) {
             return null;
         }
@@ -172,6 +181,9 @@ class grading_report_renderer extends \core\output\plugin_renderer_base {
         // We need to add some to this because the tr and actions templates both use fields from parent as well as row.
         // Otherwise some action menu elements may be incomplete.
         $data->coursework = self::prepare_coursework_data($coursework);
+        $participantcontextid = $allocatabletype === 'user' ? \context_user::instance($allocatableid)->id : null;
+        $data->submissiontype->user->picture =
+            user::get_picture_url_from_context_id($participantcontextid, $allocatable->picture);
         return $data;
     }
 

--- a/classes/renderers/grading_report_renderer.php
+++ b/classes/renderers/grading_report_renderer.php
@@ -50,6 +50,9 @@ class grading_report_renderer extends \core\output\plugin_renderer_base {
     public function render_grading_report(grading_report $gradingreport) {
 
         $tablerows = $gradingreport->get_table_rows_for_page();
+        $participantcontextids = user::get_user_picture_context_ids(
+            $gradingreport->get_coursework()->get_course_id()
+        );
 
         // Sort the table rows.
         $tablerows = $this->sort_table_rows($tablerows);
@@ -65,6 +68,10 @@ class grading_report_renderer extends \core\output\plugin_renderer_base {
         $markersarray = []; // Collect list of allocated markers while we are iterating.
         foreach ($tablerows as $rowobject) {
             $trdata = $this->get_table_row_data($gradingreport->get_coursework(), $rowobject);
+
+            // Add the user picture.
+            $participantcontextid = $participantcontextids[$rowobject->get_allocatable()->id()] ?? null;
+            $trdata->submissiontype->user->picture = user::get_picture_url_from_context_id($participantcontextid, $rowobject->get_allocatable()->picture);
 
             // Add allocated markers for data-marker and dropdown filter.
             if (!empty($trdata->markers)) {
@@ -155,7 +162,7 @@ class grading_report_renderer extends \core\output\plugin_renderer_base {
         $rowclass = $coursework->has_multiple_markers()
             ? 'mod_coursework\grading_table_row_multi'
             : 'mod_coursework\grading_table_row_single';
-        $ability = new ability(user::find($USER, false), $coursework);
+        $ability = new ability($USER->id, $coursework);
         $row = new $rowclass($coursework, $alloctable);
         if (!$ability->can('show', $row)) {
             return null;

--- a/classes/stages/assessor.php
+++ b/classes/stages/assessor.php
@@ -81,11 +81,11 @@ class assessor extends base {
     }
 
     /**
-     * @param user $assessor
+     * @param int $assessorid
      * @param \mod_coursework\models\submission $submission
      * @return bool
      */
-    public function other_parallel_stage_has_feedback_from_this_assessor($assessor, $submission) {
+    public function other_parallel_stage_has_feedback_from_this_assessor(int $assessorid, $submission) {
         global $DB;
 
         $sql = "
@@ -95,8 +95,7 @@ class assessor extends base {
             AND submissionid = ?
             AND stage_identifier LIKE '{$this->type()}%'
         ";
-        return $DB->record_exists_sql($sql, [$assessor->id(),
-                                                  $submission->id]);
+        return $DB->record_exists_sql($sql, [$assessorid, $submission->id]);
     }
 
     /**

--- a/classes/stages/base.php
+++ b/classes/stages/base.php
@@ -561,18 +561,19 @@ abstract class base {
     }
 
     /**
-     * @param $assessor
+     * Is the specified user an assessor?
+     * @param int $userid
      * @return bool
      */
-    public function user_is_assessor($assessor) {
-        if (!isset(self::$selfcache['user_is_assessor'][$this->coursework->id][$assessor->id])) {
-            $enrolled = is_enrolled($this->coursework->get_course_context(), $assessor);
+    public function user_is_assessor(int $userid): bool {
+        if (!isset(self::$selfcache['user_is_assessor'][$this->coursework->id][$userid])) {
+            $enrolled = is_enrolled($this->coursework->get_course_context(), $userid);
             $hasmoduleassessorcapability =
-                ($enrolled && has_capability($this->assessor_capability(), $this->coursework->get_context(), $assessor))
-                || is_primary_admin($assessor->id);
-            self::$selfcache['user_is_assessor'][$this->coursework->id][$assessor->id] = $hasmoduleassessorcapability;
+                ($enrolled && has_capability($this->assessor_capability(), $this->coursework->get_context(), $userid))
+                || is_primary_admin($userid);
+            self::$selfcache['user_is_assessor'][$this->coursework->id][$userid] = $hasmoduleassessorcapability;
         }
-        return self::$selfcache['user_is_assessor'][$this->coursework->id][$assessor->id];
+        return self::$selfcache['user_is_assessor'][$this->coursework->id][$userid];
     }
 
     /**
@@ -735,11 +736,11 @@ abstract class base {
     }
 
     /**
-     * @param user $assessor
+     * @param int $assessorid
      * @param submission $submission
      * @return bool
      */
-    public function other_parallel_stage_has_feedback_from_this_assessor($assessor, $submission) {
+    public function other_parallel_stage_has_feedback_from_this_assessor(int $assessorid, $submission) {
         return false;
     }
 

--- a/lang/en/coursework.php
+++ b/lang/en/coursework.php
@@ -868,6 +868,7 @@ $string['submission_notification_html'] = '<p>Dear {$a->name},</p><p> A submissi
 $string['submission_notification_subject'] = 'A submission has been made in {$a}';
 $string['submission_notification_text'] = 'Dear {$a->name},'."\n\n".'A submission has been made in the {$a->coursework_name} coursework.';
 $string['coursework:submitonbehalfof'] = 'Submit work on behalf of a student';
+$string['submitonbehalf'] = 'Submit on behalf';
 $string['submitonbehalfofstudent'] = 'Submit work on behalf of {$a}';
 $string['submitted_late'] = 'Submitted late';
 $string['submitted'] = 'Submitted';

--- a/renderers/object_renderer.php
+++ b/renderers/object_renderer.php
@@ -90,7 +90,7 @@ class mod_coursework_object_renderer extends plugin_renderer_base {
 
             // Marker image.
             if ($feedback->assessor) {
-                $template->markerimg = $feedback->get_assessor_user_picture()->get_url($this->page)->out(false);
+                $template->markerimg = $feedback->assessor()->get_user_picture_url();
             }
         }
 
@@ -245,7 +245,7 @@ class mod_coursework_object_renderer extends plugin_renderer_base {
 
         global $USER;
 
-        $ability = new ability(user::find($USER), $files->get_coursework());
+        $ability = new ability($USER->id, $files->get_coursework());
 
         $coursework = $files->get_coursework();
         $submissionfiles = $files->get_files();
@@ -284,7 +284,7 @@ class mod_coursework_object_renderer extends plugin_renderer_base {
 
         global $USER;
 
-        $ability = new ability(user::find($USER), $files->get_coursework());
+        $ability = new ability($USER->id, $files->get_coursework());
 
         $coursework = $files->get_coursework();
         $submissionfiles = $files->get_files();
@@ -949,7 +949,7 @@ class mod_coursework_object_renderer extends plugin_renderer_base {
     protected function render_resubmit_to_plagiarism_button($coursework, $submission) {
         global $USER;
 
-        $ability = new ability(user::find($USER), $coursework);
+        $ability = new ability($USER->id, $coursework);
         $html = '';
         if ($coursework->plagiarism_enbled() && $ability->can('resubmit_to_plagiarism', $submission)) {
             // Show the resubmit to plagiarism button if the user is allowed to do this.
@@ -1046,7 +1046,7 @@ class mod_coursework_object_renderer extends plugin_renderer_base {
 
         $finalfeedback = $submission->get_final_feedback();
 
-        $ability = new ability(user::find($USER), $submission->get_coursework());
+        $ability = new ability($USER->id, $submission->get_coursework());
 
         if ($finalfeedback && $ability->can('show', $finalfeedback)) {
             $html .= $this->render_feedback($finalfeedback);
@@ -1192,7 +1192,7 @@ class mod_coursework_object_renderer extends plugin_renderer_base {
             );
         }
 
-        $ability = new ability(user::find($USER), $coursework);
+        $ability = new ability($USER->id, $coursework);
         $disabledelement = (!$personaldeadline ||($personaldeadline && $ability->can('edit', $personaldeadline)) ) ? "" : " disabled='disabled' ";
 
         $rowhtml = '<tr id="'. $personaldeadlinerow->get_allocatable()->type() . '_' . $personaldeadlinerow->get_allocatable()->id().'">';

--- a/renderers/page_renderer.php
+++ b/renderers/page_renderer.php
@@ -241,7 +241,7 @@ class mod_coursework_page_renderer extends plugin_renderer_base {
         }
 
         // WIP - student overview.
-        $ability = new ability($student, $coursework);
+        $ability = new ability($student->id(), $coursework);
 
         if ($coursework->start_date_has_passed()) {
             // Main data.

--- a/tests/phpunit/ability_test.php
+++ b/tests/phpunit/ability_test.php
@@ -36,13 +36,12 @@ final class ability_test extends advanced_testcase {
     }
 
     public function test_allow_saves_rules(): void {
-        $ability = new ability($this->create_a_teacher(), $this->create_a_coursework());
+        $ability = new ability($this->create_a_teacher()->id(), $this->create_a_coursework());
         $this->assertTrue($ability->can('show', $this->get_coursework()));
     }
 
     public function test_ridiculous_things_are_banned_by_default_if_not_mentioned(): void {
-        $ability = new ability($this->create_a_teacher(), $this->create_a_coursework());
+        $ability = new ability($this->create_a_teacher()->id(), $this->create_a_coursework());
         $this->assertFalse($ability->can('set_fire_to', $this->get_coursework()));
     }
-
 }


### PR DESCRIPTION
Main purpose of these changes is to stop the multiple individual DB queries per row that are generated when the grading page loads.  Changes include the below (which together eliminate the multiple queries per row):

- change the ability class constructor to require user ID not user object (so avoiding having to get user object from DB as in `new ability(user::find($USER),...)`
- up front on page load, get all extensions, personal deadlines and user picture data so we don't end up with separate queries for each row
- when generating actions menu for each row, avoid `$ability->can()` as this also generates multiple queries per row.  It is not necessary and using moodle's has_capability is fine in this context
- reducing the number of times that the user class goes back to database to get user details (i.e. ensure it uses data it already has)