### PR TITLE
Ctp 5133 unfinalise

### DIFF
--- a/actions/revert.php
+++ b/actions/revert.php
@@ -48,14 +48,14 @@ if (!has_capability('mod/coursework:revertfinalised', $PAGE->context)) {
     redirect($url, $message);
 }
 
-if ($submission->is_late()) {
+if ($submission->is_late() && !$coursework->allow_late_submissions()) {
     redirect(
         $url,
         get_string('extendbeforerevert', 'coursework'), null, \core\output\notification::NOTIFY_ERROR
     );
 }
 
-$submission->finalised = 0;
+$submission->finalisedstatus = submission::FINALISED_STATUS_MANUALLY_UNFINALISED;
 $submission->save();
 
 $message = get_string('changessaved');

--- a/backup/moodle2/backup_coursework_stepslib.php
+++ b/backup/moodle2/backup_coursework_stepslib.php
@@ -186,7 +186,7 @@ class backup_coursework_activity_structure_step extends backup_activity_structur
                                                       "authorid",
                                                       "timecreated",
                                                       "timemodified",
-                                                      "finalised",
+                                                      "finalisedstatus",
                                                       "manualsrscode",
                                                       "createdby",
                                                       "lastupdatedby",

--- a/backup/moodle2/restore_coursework_stepslib.php
+++ b/backup/moodle2/restore_coursework_stepslib.php
@@ -86,6 +86,12 @@ class restore_coursework_activity_structure_step extends restore_activity_struct
         $data->createdby = $this->get_mappingid('user', $data->createdby);
         $data->lastupdatedby = $this->get_mappingid('user', $data->lastupdatedby);
 
+        // Finalised field was renamed to finalisedstatus.
+        if (!isset($data->finalisedstatus) && isset($data->finalised)) {
+            $data->finalisedstatus = $data->finalised;
+            unset($data->finalised);
+        }
+
         $this->fixallocatable($data);
 
         $this->updatedate(['timemodified',
@@ -100,7 +106,7 @@ class restore_coursework_activity_structure_step extends restore_activity_struct
                                   'firstpublished' => null,
                                   'lastpublished' => null,
                                   'timesubmitted' => null,
-                                  'finalised' => 0,
+                                  'finalisedstatus' => 0,
                                   'manualsrscode' => ''],
                             $data);
 

--- a/classes/ability.php
+++ b/classes/ability.php
@@ -481,8 +481,11 @@ class ability extends \mod_coursework\framework\ability {
                         $this->set_message('Cannot submit past the deadline');
                         return true;
                     } else {
-                        if ($submission->persisted() &&
-                            $submission->finalisedstatus != submission::FINALISED_STATUS_MANUALLY_UNFINALISED) {
+                        if (
+                            $submission->persisted()
+                            &&
+                            $submission->finalisedstatus != submission::FINALISED_STATUS_MANUALLY_UNFINALISED
+                        ) {
                             $this->set_message('Cannot update submissions past the deadline');
                             return true;
                         }

--- a/classes/ability.php
+++ b/classes/ability.php
@@ -481,7 +481,8 @@ class ability extends \mod_coursework\framework\ability {
                         $this->set_message('Cannot submit past the deadline');
                         return true;
                     } else {
-                        if ($submission->persisted()) {
+                        if ($submission->persisted() &&
+                            $submission->finalisedstatus != submission::FINALISED_STATUS_MANUALLY_UNFINALISED) {
                             $this->set_message('Cannot update submissions past the deadline');
                             return true;
                         }

--- a/classes/controllers/submissions_controller.php
+++ b/classes/controllers/submissions_controller.php
@@ -154,7 +154,8 @@ class submissions_controller extends controller_base {
 
         $submission = new submission();
         $submission->courseworkid = $this->coursework->id;
-        $submission->finalised = $this->params['finalised'] ? 1 : 0;
+        $submission->finalisedstatus = $this->params['finalised']
+            ? submission::FINALISED_STATUS_FINALISED : submission::FINALISED_STATUS_NOT_FINALISED;
         $submission->allocatableid = $this->params['allocatableid'];
         $submission->createdby = $USER->id;
         $submission->lastupdatedby = $USER->id;
@@ -166,10 +167,10 @@ class submissions_controller extends controller_base {
         if ($this->coursework->personal_deadlines_enabled()) {
             // Check is submission has a valid personal deadline or a valid extension
             if (!$this->has_valid_personal_deadline($submission) && !$this->has_valid_extension($submission)) {
-                $submission->finalised = 1;
+                $submission->finalisedstatus = submission::FINALISED_STATUS_FINALISED;
             }
         } else if ($this->coursework->deadline_has_passed() && !$this->has_valid_extension($submission)) {
-            $submission->finalised = 1;
+            $submission->finalisedstatus = submission::FINALISED_STATUS_FINALISED;
         }
 
         $ability = new ability($USER->id, $this->coursework);
@@ -207,13 +208,13 @@ class submissions_controller extends controller_base {
         $submission->submit_plagiarism();
 
         $mailer = new mailer($this->coursework);
-        if ($CFG->coursework_allsubmissionreceipt || $submission->finalised) {
+        if ($CFG->coursework_allsubmissionreceipt || $submission->finalisedstatus == submission::FINALISED_STATUS_FINALISED) {
             foreach ($submission->get_students() as $student) {
-                $mailer->send_submission_receipt($student, $submission->finalised);
+                $mailer->send_submission_receipt($student, $submission->finalisedstatus == submission::FINALISED_STATUS_FINALISED);
             }
         }
 
-        if ($submission->finalised) {
+        if ($submission->finalisedstatus == submission::FINALISED_STATUS_FINALISED) {
             if (!$submission->get_coursework()->has_deadline()) {
 
                 $useridcommaseparatedlist = $submission->get_coursework()->get_submission_notification_users();
@@ -263,11 +264,13 @@ class submissions_controller extends controller_base {
         }
 
         $notifyaboutfinalisation = false;
-        $incomingfinalisedsetting = $this->params['finalised'] ? 1 : 0;
-        if ($incomingfinalisedsetting == 1 && $submission->finalised == 0) {
+        $incomingfinalisedsetting = $this->params['finalised']
+            ? submission::FINALISED_STATUS_FINALISED : submission::FINALISED_STATUS_NOT_FINALISED;
+        if ($incomingfinalisedsetting == submission::FINALISED_STATUS_FINALISED
+            && $submission->finalisedstatus != submission::FINALISED_STATUS_FINALISED) {
             $notifyaboutfinalisation = true;
         }
-        $submission->finalised = $incomingfinalisedsetting;
+        $submission->finalisedstatus = $incomingfinalisedsetting;
         $submission->lastupdatedby = $USER->id;
         $submission->timesubmitted = time();
 
@@ -320,7 +323,7 @@ class submissions_controller extends controller_base {
             throw new access_denied($this->coursework);
         }
 
-        $submission->finalised = 1;
+        $submission->finalisedstatus = submission::FINALISED_STATUS_FINALISED;
         $submission->save();
 
         // Email the user. Best to do this as an event after 2.7 so as to keep the page fast.
@@ -335,7 +338,8 @@ class submissions_controller extends controller_base {
     protected function unfinalise_submission() {
         global $DB;
 
-        $allocatableids = (!is_array($this->params['allocatableid'])) ? [$this->params['allocatableid']] : $this->params['allocatableid'];
+        $allocatableids = (!is_array($this->params['allocatableid']))
+            ? [$this->params['allocatableid']] : $this->params['allocatableid'];
 
         $personaldeadlinepageurl = new \moodle_url('/mod/coursework/actions/personal_deadline.php',
             ['id' => $this->coursework->get_coursemodule_id(), 'multipleuserdeadlines' => 1, 'setpersonaldeadlinespage' => 1,
@@ -350,7 +354,7 @@ class submissions_controller extends controller_base {
                 $submission = \mod_coursework\models\submission::find($submissiondb);
 
                 if ($submission->can_be_unfinalised()) {
-                    $submission->finalised = 0;
+                    $submission->finalisedstatus = submission::FINALISED_STATUS_MANUALLY_UNFINALISED;
                     $submission->save();
                     $personaldeadlinepageurl->param("allocatableid_arr[$aid]", $aid);
                     $changedeadlines = true;

--- a/classes/controllers/submissions_controller.php
+++ b/classes/controllers/submissions_controller.php
@@ -208,13 +208,13 @@ class submissions_controller extends controller_base {
         $submission->submit_plagiarism();
 
         $mailer = new mailer($this->coursework);
-        if ($CFG->coursework_allsubmissionreceipt || $submission->finalisedstatus == submission::FINALISED_STATUS_FINALISED) {
+        if ($CFG->coursework_allsubmissionreceipt || $submission->is_finalised()) {
             foreach ($submission->get_students() as $student) {
-                $mailer->send_submission_receipt($student, $submission->finalisedstatus == submission::FINALISED_STATUS_FINALISED);
+                $mailer->send_submission_receipt($student, $submission->is_finalised());
             }
         }
 
-        if ($submission->finalisedstatus == submission::FINALISED_STATUS_FINALISED) {
+        if ($submission->is_finalised()) {
             if (!$submission->get_coursework()->has_deadline()) {
 
                 $useridcommaseparatedlist = $submission->get_coursework()->get_submission_notification_users();
@@ -263,13 +263,11 @@ class submissions_controller extends controller_base {
             throw new access_denied($this->coursework, $ability->get_last_message());
         }
 
-        $notifyaboutfinalisation = false;
         $incomingfinalisedsetting = $this->params['finalised']
             ? submission::FINALISED_STATUS_FINALISED : submission::FINALISED_STATUS_NOT_FINALISED;
-        if ($incomingfinalisedsetting == submission::FINALISED_STATUS_FINALISED
-            && $submission->finalisedstatus != submission::FINALISED_STATUS_FINALISED) {
-            $notifyaboutfinalisation = true;
-        }
+        $notifyaboutfinalisation = $incomingfinalisedsetting == submission::FINALISED_STATUS_FINALISED
+            && !$submission->is_finalised();
+
         $submission->finalisedstatus = $incomingfinalisedsetting;
         $submission->lastupdatedby = $USER->id;
         $submission->timesubmitted = time();

--- a/classes/cron.php
+++ b/classes/cron.php
@@ -343,15 +343,15 @@ class cron {
     }
 
     /**
-     * Updates all DB columns where the deadline was before now, so that finalised = 1
+     * Updates all DB columns where the deadline was before now - updates 'finalisedstatus' to submission::FINALISED_STATUS_FINALISED
      */
     public static function finalise_any_submissions_where_the_deadline_has_passed($courseworkid = null) {
-        $submissions = submission::unfinalised_past_deadline($courseworkid);
+        $submissions = submission::not_finalised_past_deadline($courseworkid);
         foreach ($submissions as $submission) {
             // Doing this one at a time so that the email will arrive with finalisation already
             // done. Would not want them to check straight away and then find they could still
             // edit it.
-            $submission->update_attribute('finalised', 1);
+            $submission->update_attribute('finalisedstatus', submission::FINALISED_STATUS_FINALISED);
             submission::remove_cache($submission->courseworkid);
             // Slightly wasteful to keep re-fetching the coursework :-/
             $mailer = new mailer($submission->get_coursework());

--- a/classes/forms/student_submission_form.php
+++ b/classes/forms/student_submission_form.php
@@ -135,7 +135,7 @@ class student_submission_form extends moodleform {
 
                 if ($filecount > 0) { // Check that there is a file before updating to finalised.
                     // Confirm finalise state.
-                    $submission->finalised = 1;
+                    $submission->finalisedstatus = submission::FINALISED_STATUS_FINALISED;
                     $submission->save();
 
                     // Rename the uploaded file to the submission hash.

--- a/classes/models/coursework.php
+++ b/classes/models/coursework.php
@@ -1528,7 +1528,7 @@ class coursework extends table_base {
      */
     public function get_unfinalised_students($fields = 'u.id, u.firstname, u.lastname') {
 
-        $students = get_enrolled_users(\context_course::instance($this->get_course_id()), 'mod/coursework:submit', 0, $fields);
+        $students = get_enrolled_users(context_course::instance($this->get_course_id()), 'mod/coursework:submit', 0, $fields);
         submission::fill_pool_coursework($this->id);
         $alreadyfinalised = submission::$pool[$this->id]['finalisedstatus'][submission::FINALISED_STATUS_FINALISED] ?? [];
         foreach ($alreadyfinalised as $submission) {

--- a/classes/models/outstanding_marking.php
+++ b/classes/models/outstanding_marking.php
@@ -104,17 +104,17 @@ class outstanding_marking {
         }
 
         $sql = "SELECT cs.id as submissionid
-                                 FROM       {coursework_submissions}    cs
-                                 LEFT JOIN  {coursework_feedbacks}   f
-                                 ON          cs.id = f.submissionid
-                                 {$sqltable}
-                                 WHERE     f.id IS NULL
-                                 AND cs.finalised = 1
-                                 AND cs.courseworkid = :courseworkid
-                                  {$sqlextra}
-                                 ";
+                    FROM       {coursework_submissions}    cs
+                    LEFT JOIN  {coursework_feedbacks}   f
+                    ON          cs.id = f.submissionid
+                    {$sqltable}
+                    WHERE     f.id IS NULL
+                    AND cs.finalisedstatus = :submissionfinalised
+                    AND cs.courseworkid = :courseworkid
+                    {$sqlextra}";
 
         $sqlparams['courseworkid'] = $courseworkid;
+        $sqlparams['submissionfinalised'] = submission::FINALISED_STATUS_FINALISED;
 
         return  $DB->get_records_sql($sql, $sqlparams);
     }
@@ -189,7 +189,7 @@ class outstanding_marking {
                                       FROM 	{coursework_submissions}	cs LEFT JOIN
                                             {coursework_feedbacks} f ON   cs.id = f.submissionid
                                             {$sqltable}
-                                     WHERE cs.finalised = 1
+                                     WHERE cs.finalisedstatus = :submissionfinalised
                                        AND cs.courseworkid = :courseworkid
                                           AND (f.assessorid != :assessorid OR f.assessorid IS NULL)
                                           {$sqlextra}
@@ -205,6 +205,7 @@ class outstanding_marking {
         $sqlparams['courseworkid'] = $courseworkid;
         $sqlparams['numofmarkers'] = $numberofmarkers;
         $sqlparams['assessorid'] = $userid;
+        $sqlparams['submissionfinalised'] = submission::FINALISED_STATUS_FINALISED;
 
         return  $DB->get_records_sql($sql, $sqlparams);
     }
@@ -222,13 +223,14 @@ class outstanding_marking {
                                       FROM 	{coursework_submissions} cs ,
                                             {coursework_feedbacks} f
                                      WHERE  f.submissionid= cs.id
-                                        AND cs.finalised = 1
+                                        AND cs.finalisedstatus = :submissionfinalised
                                         AND cs.courseworkid = :courseworkid
                                         GROUP BY cs.id
                                         HAVING (COUNT(cs.id) = :numofmarkers)";
 
         $sqlparams['numofmarkers'] = $numberofmarkers;
         $sqlparams['courseworkid'] = $courseworkid;
+        $sqlparams['submissionfinalised'] = submission::FINALISED_STATUS_FINALISED;
 
         return $DB->get_records_sql($sql, $sqlparams);
     }

--- a/classes/models/submission.php
+++ b/classes/models/submission.php
@@ -629,8 +629,11 @@ class submission extends table_base implements \renderable {
         }
 
         // Submitted with only some of the required grades in place.
-        if ($this->finalisedstatus == self::FINALISED_STATUS_FINALISED &&
-            count($assessorfeedbacks) > 0 &&
+        if (
+            $this->is_finalised()
+            &&
+            count($assessorfeedbacks) > 0
+            &&
             (count($assessorfeedbacks) < $this->get_coursework()->numberofmarkers || $this->any_editable_feedback_exists())
         ) {
 
@@ -638,7 +641,7 @@ class submission extends table_base implements \renderable {
         }
 
         // Student has marked this as finalised.
-        if ($this->finalisedstatus == self::FINALISED_STATUS_FINALISED) {
+        if ($this->is_finalised()) {
             return self::FINALISED;
         }
 
@@ -917,8 +920,12 @@ class submission extends table_base implements \renderable {
         return $this->get_state() >= self::FULLY_GRADED;
     }
 
-    public function is_finalised() {
-        return $this->get_state() == self::FINALISED;
+    /**
+     * Is this submission marked as finalised?
+     * @return bool
+     */
+    public function is_finalised(): bool {
+        return $this->finalisedstatus == self::FINALISED_STATUS_FINALISED;
     }
 
     /**
@@ -1383,7 +1390,7 @@ class submission extends table_base implements \renderable {
 
         $editablefeedbacks = [];
         $coursework = $this->get_coursework();
-        if ($coursework->numberofmarkers > 1 && $this->finalisedstatus == self::FINALISED_STATUS_FINALISED) {
+        if ($coursework->numberofmarkers > 1 && $this->is_finalised()) {
             $editablefeedbacks = isset(feedback::$pool[$coursework->id]['submissionid-finalised'][$this->id . '-0']) ?
                 feedback::$pool[$coursework->id]['submissionid-finalised'][$this->id . '-0'] : [];
         }
@@ -1398,8 +1405,7 @@ class submission extends table_base implements \renderable {
     public function editable_final_feedback_exist() {
         if (!isset($this->editable_final_feedback)) {
             $this->editable_final_feedback = false;
-            if ($this->finalisedstatus == self::FINALISED_STATUS_FINALISED) {
-
+            if ($this->is_finalised()) {
                 $coursework = $this->get_coursework();
                 $finalfeedback = feedback::get_object($coursework->id, 'submissionid-stage_identifier', [$this->id, 'final_agreed_1']);
                 if ($finalfeedback && $finalfeedback->finalised == 0 && $finalfeedback->assessorid <> 0) {

--- a/classes/personal_deadline/table/row/builder.php
+++ b/classes/personal_deadline/table/row/builder.php
@@ -209,7 +209,7 @@ class builder implements user_row {
 
         $statustext = get_string('statusnotsubmitted', 'mod_coursework');
 
-        if (!empty($submission) && $submission->is_finalised()) {
+        if (!empty($submission) && $submission->get_state() == $submission::FINALISED) {
             $statustext = get_string('finalisedsubmission', 'mod_coursework');
         } else if (!empty($submission)) {
             $statustext = $submission->get_status_text();

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -434,7 +434,7 @@ class provider implements
     /**
      * Formats and then exports the user's submission data.
      *
-     * @param  \stdClass $submission The coursework submission object
+     * @param  \stdClass $submission The coursework submission DB record.
      * @param  \context $context The context object
      * @param  array $currentpath Current directory path that we are exporting to.
      */

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -30,6 +30,8 @@ use core_privacy\local\request\transform;
 use core_privacy\local\request\helper;
 use core_privacy\local\request\userlist;
 use core_privacy\local\request\approved_userlist;
+use mod_coursework\models\submission;
+
 /**
  * Privacy Subsystem implementation for coursework.
  *
@@ -445,7 +447,7 @@ class provider implements
             'timemodified' => transform::datetime($submission->timemodified),
             'timesubmitted' => transform::datetime($submission->timesubmitted),
             'createdby' => $submission->createdby,
-            'finalised' => transform::yesno($submission->finalised),
+            'finalised' => transform::yesno($submission->finalisedstatus == submission::FINALISED_STATUS_FINALISED),
         ];
         writer::with_context($context)
             ->export_data(array_merge($currentpath, [get_string('privacy:submissionpath', 'mod_coursework')]), $submissiondata);

--- a/classes/render_helpers/grading_report/cells/plagiarism_flag_cell.php
+++ b/classes/render_helpers/grading_report/cells/plagiarism_flag_cell.php
@@ -49,8 +49,7 @@ class plagiarism_flag_cell extends cell_base {
         $content = '';
         $ability = new ability($USER->id, $rowobject->get_coursework());
 
-        if ($rowobject->has_submission()
-            && $rowobject->get_submission()->finalisedstatus == submission::FINALISED_STATUS_FINALISED) {
+        if ($rowobject->has_submission() && $rowobject->get_submission()->is_finalised()) {
             $plagiarismflagparams = [
                 'submissionid' => $rowobject->get_submission()->id,
             ];

--- a/classes/render_helpers/grading_report/cells/plagiarism_flag_cell.php
+++ b/classes/render_helpers/grading_report/cells/plagiarism_flag_cell.php
@@ -49,7 +49,8 @@ class plagiarism_flag_cell extends cell_base {
         $content = '';
         $ability = new ability($USER->id, $rowobject->get_coursework());
 
-        if ($rowobject->has_submission() && $rowobject->get_submission()->finalised) {
+        if ($rowobject->has_submission()
+            && $rowobject->get_submission()->finalisedstatus == submission::FINALISED_STATUS_FINALISED) {
             $plagiarismflagparams = [
                 'submissionid' => $rowobject->get_submission()->id,
             ];

--- a/classes/render_helpers/grading_report/cells/submission_cell.php
+++ b/classes/render_helpers/grading_report/cells/submission_cell.php
@@ -79,8 +79,11 @@ class submission_cell extends cell_base {
                                                                      'createdby' => $USER->id,
                                                                  ]);
 
-        if (($rowobject->get_submission() && $rowobject->get_submission()->finalisedstatus != submission::FINALISED_STATUS_FINALISED)
-            || !$rowobject->get_submission()) {
+        if (
+            ($rowobject->get_submission() && !$rowobject->get_submission()->is_finalised())
+            ||
+            !$rowobject->get_submission()
+        ) {
 
             if ($ability->can('new', $submissiononbehalfofallocatable) && (!$rowobject->get_coursework()->has_deadline()
                     || $rowobject->get_coursework()->allow_late_submissions()

--- a/classes/render_helpers/grading_report/cells/submission_cell.php
+++ b/classes/render_helpers/grading_report/cells/submission_cell.php
@@ -79,7 +79,7 @@ class submission_cell extends cell_base {
                                                                      'createdby' => $USER->id,
                                                                  ]);
 
-        if (($rowobject->get_submission()&& !$rowobject->get_submission()->finalised)
+        if (($rowobject->get_submission() && $rowobject->get_submission()->finalisedstatus != submission::FINALISED_STATUS_FINALISED)
             || !$rowobject->get_submission()) {
 
             if ($ability->can('new', $submissiononbehalfofallocatable) && (!$rowobject->get_coursework()->has_deadline()

--- a/classes/render_helpers/grading_report/data/actions_cell_data.php
+++ b/classes/render_helpers/grading_report/data/actions_cell_data.php
@@ -129,7 +129,7 @@ class actions_cell_data extends cell_data_base {
 
         // If submission is finalised, no actions needed.
         $submission = $rowsbase->get_submission();
-        if ($submission && $submission->finalisedstatus == submission::FINALISED_STATUS_FINALISED) {
+        if ($submission && $submission->is_finalised()) {
             return;
         }
 
@@ -164,7 +164,7 @@ class actions_cell_data extends cell_data_base {
      * @param grading_table_row_base $rowsbase The row base object
      */
     protected function set_finalise_data(stdClass $data, grading_table_row_base $rowsbase): void {
-        if (!$rowsbase->get_submission() || $rowsbase->get_submission()->finalisedstatus == submission::FINALISED_STATUS_FINALISED) {
+        if (!$rowsbase->get_submission() || $rowsbase->get_submission()->is_finalised()) {
             return;
         }
         if ($this->ability->can('finalise', $rowsbase->get_submission())) {
@@ -183,7 +183,7 @@ class actions_cell_data extends cell_data_base {
      * @param grading_table_row_base $rowsbase The row base object
      */
     protected function set_unfinalise_data(stdClass $data, grading_table_row_base $rowsbase): void {
-        if (!$rowsbase->get_submission() || $rowsbase->get_submission()->finalisedstatus != submission::FINALISED_STATUS_FINALISED) {
+        if (!$rowsbase->get_submission() || !$rowsbase->get_submission()->is_finalised()) {
             return;
         }
         if ($this->ability->can('revert', $rowsbase->get_submission())) {
@@ -210,7 +210,7 @@ class actions_cell_data extends cell_data_base {
         // Early returns for conditions where plagiarism data should not be shown.
         if (!$this->coursework->plagiarism_flagging_enbled() ||
             !$rowsbase->get_submission() ||
-            !$rowsbase->get_submission()->finalisedstatus == submission::FINALISED_STATUS_FINALISED) {
+            !$rowsbase->get_submission()->is_finalised()) {
             return;
         }
 
@@ -262,8 +262,11 @@ class actions_cell_data extends cell_data_base {
      */
     protected function set_personal_deadline_data(stdClass $data, grading_table_row_base $rowsbase): void {
         // We avoid using $this->ability->can() in this context as it creates multiple DB queries per row.
-        if (!has_capability('mod/coursework:editpersonaldeadline', $this->coursework->get_context())
-            || !$rowsbase->get_coursework()->personal_deadlines_enabled()) {
+        if (
+            !has_capability('mod/coursework:editpersonaldeadline', $this->coursework->get_context())
+            ||
+            !$rowsbase->get_coursework()->personal_deadlines_enabled()
+        ) {
             return;
         }
         $personaldeadlineobject = $rowsbase->get_personal_deadline();

--- a/classes/render_helpers/grading_report/data/actions_cell_data.php
+++ b/classes/render_helpers/grading_report/data/actions_cell_data.php
@@ -129,7 +129,7 @@ class actions_cell_data extends cell_data_base {
 
         // If submission is finalised, no actions needed.
         $submission = $rowsbase->get_submission();
-        if ($submission && $submission->finalised) {
+        if ($submission && $submission->finalisedstatus == submission::FINALISED_STATUS_FINALISED) {
             return;
         }
 
@@ -164,7 +164,7 @@ class actions_cell_data extends cell_data_base {
      * @param grading_table_row_base $rowsbase The row base object
      */
     protected function set_finalise_data(stdClass $data, grading_table_row_base $rowsbase): void {
-        if (!$rowsbase->get_submission() || $rowsbase->get_submission()->finalised) {
+        if (!$rowsbase->get_submission() || $rowsbase->get_submission()->finalisedstatus == submission::FINALISED_STATUS_FINALISED) {
             return;
         }
         if ($this->ability->can('finalise', $rowsbase->get_submission())) {
@@ -183,7 +183,7 @@ class actions_cell_data extends cell_data_base {
      * @param grading_table_row_base $rowsbase The row base object
      */
     protected function set_unfinalise_data(stdClass $data, grading_table_row_base $rowsbase): void {
-        if (!$rowsbase->get_submission() || !$rowsbase->get_submission()->finalised) {
+        if (!$rowsbase->get_submission() || $rowsbase->get_submission()->finalisedstatus != submission::FINALISED_STATUS_FINALISED) {
             return;
         }
         if ($this->ability->can('revert', $rowsbase->get_submission())) {
@@ -191,7 +191,7 @@ class actions_cell_data extends cell_data_base {
                 '/mod/coursework/actions/revert.php',
                 [
                     'cmid' => $rowsbase->get_course_module_id(),
-                    'submissionid' => $rowsbase->get_submission_id()
+                    'submissionid' => $rowsbase->get_submission_id(),
                 ]);
             $data->unfinalise = new stdClass();
             $data->unfinalise->url = $url->out(false);
@@ -210,7 +210,7 @@ class actions_cell_data extends cell_data_base {
         // Early returns for conditions where plagiarism data should not be shown.
         if (!$this->coursework->plagiarism_flagging_enbled() ||
             !$rowsbase->get_submission() ||
-            !$rowsbase->get_submission()->finalised) {
+            !$rowsbase->get_submission()->finalisedstatus == submission::FINALISED_STATUS_FINALISED) {
             return;
         }
 
@@ -262,8 +262,8 @@ class actions_cell_data extends cell_data_base {
      */
     protected function set_personal_deadline_data(stdClass $data, grading_table_row_base $rowsbase): void {
         // We avoid using $this->ability->can() in this context as it creates multiple DB queries per row.
-        $hascapability = has_capability('mod/coursework:editpersonaldeadline', $this->coursework->get_context());
-        if (!$hascapability) {
+        if (!has_capability('mod/coursework:editpersonaldeadline', $this->coursework->get_context())
+            || !$rowsbase->get_coursework()->personal_deadlines_enabled()) {
             return;
         }
         $personaldeadlineobject = $rowsbase->get_personal_deadline();

--- a/classes/render_helpers/grading_report/data/submission_cell_data.php
+++ b/classes/render_helpers/grading_report/data/submission_cell_data.php
@@ -73,8 +73,7 @@ class submission_cell_data extends cell_data_base {
         $data->datemodified = $submission->time_submitted();
         $data->submissiondata = new stdClass();
         $data->submissiondata->files = $this->get_submission_files_data($rowobject);
-        // Finalised is string 0 when not finalised.
-        $data->submissiondata->finalised = $submission->finalised;
+        $data->submissiondata->finalised = $submission->finalisedstatus == submission::FINALISED_STATUS_FINALISED;
 
         $this->add_plagiarism_data($data->submissiondata, $submission);
         $this->add_late_submission_data($data->submissiondata, $submission);

--- a/classes/render_helpers/grading_report/data/submission_cell_data.php
+++ b/classes/render_helpers/grading_report/data/submission_cell_data.php
@@ -73,7 +73,7 @@ class submission_cell_data extends cell_data_base {
         $data->datemodified = $submission->time_submitted();
         $data->submissiondata = new stdClass();
         $data->submissiondata->files = $this->get_submission_files_data($rowobject);
-        $data->submissiondata->finalised = $submission->finalisedstatus == submission::FINALISED_STATUS_FINALISED;
+        $data->submissiondata->finalised = $submission->is_finalised();
 
         $this->add_plagiarism_data($data->submissiondata, $submission);
         $this->add_late_submission_data($data->submissiondata, $submission);

--- a/classes/render_helpers/grading_report/sub_rows/multi_marker_feedback_sub_rows.php
+++ b/classes/render_helpers/grading_report/sub_rows/multi_marker_feedback_sub_rows.php
@@ -29,6 +29,7 @@ use mod_coursework\assessor_feedback_row;
 use mod_coursework\assessor_feedback_table;
 use mod_coursework\grade_judge;
 use mod_coursework\models\feedback;
+use mod_coursework\models\submission;
 use mod_coursework\models\user;
 use mod_coursework\router;
 use moodle_url;
@@ -192,7 +193,7 @@ class multi_marker_feedback_sub_rows implements sub_rows_interface {
 
             if ($assessorfeedbacktable->get_submission() &&
                     ($assessorfeedbacktable->get_coursework()->deadline_has_passed() &&
-                    $assessorfeedbacktable->get_submission()->finalised)) {
+                    $assessorfeedbacktable->get_submission()->finalisedstatus == submission::FINALISED_STATUS_FINALISED)) {
 
                 $tablehtml = '<tr><td colspan = "11" class="nograde" ><table class="nograde">';
                 $tablehtml .= '<tr>' . get_string('nogradescomments', 'mod_coursework') . '</tr>';

--- a/classes/render_helpers/grading_report/sub_rows/multi_marker_feedback_sub_rows.php
+++ b/classes/render_helpers/grading_report/sub_rows/multi_marker_feedback_sub_rows.php
@@ -193,7 +193,7 @@ class multi_marker_feedback_sub_rows implements sub_rows_interface {
 
             if ($assessorfeedbacktable->get_submission() &&
                     ($assessorfeedbacktable->get_coursework()->deadline_has_passed() &&
-                    $assessorfeedbacktable->get_submission()->finalisedstatus == submission::FINALISED_STATUS_FINALISED)) {
+                    $assessorfeedbacktable->get_submission()->is_finalised())) {
 
                 $tablehtml = '<tr><td colspan = "11" class="nograde" ><table class="nograde">';
                 $tablehtml .= '<tr>' . get_string('nogradescomments', 'mod_coursework') . '</tr>';

--- a/classes/services/submission_figures.php
+++ b/classes/services/submission_figures.php
@@ -143,7 +143,7 @@ class submission_figures {
     private static function remove_ungradable_submissions(array $submissions): array {
         foreach ($submissions as $submission) {
 
-            if ($submission->finalisedstatus != submission::FINALISED_STATUS_FINALISED
+            if (!$submission->is_finalised()
                 || !empty($submission->get_final_grade())
                 || (has_capability('mod/coursework:addallocatedagreedgrade', $submission->get_coursework()->get_context())
                     && !$submission->is_assessor_initial_grader() && $submission->all_initial_graded())) {

--- a/classes/services/submission_figures.php
+++ b/classes/services/submission_figures.php
@@ -143,7 +143,7 @@ class submission_figures {
     private static function remove_ungradable_submissions(array $submissions): array {
         foreach ($submissions as $submission) {
 
-            if (empty($submission->finalised)
+            if ($submission->finalisedstatus != submission::FINALISED_STATUS_FINALISED
                 || !empty($submission->get_final_grade())
                 || (has_capability('mod/coursework:addallocatedagreedgrade', $submission->get_coursework()->get_context())
                     && !$submission->is_assessor_initial_grader() && $submission->all_initial_graded())) {

--- a/db/install.xml
+++ b/db/install.xml
@@ -117,7 +117,7 @@
         <FIELD NAME="authorid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="finalised" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="If true, then the student can no longer add files."/>
+        <FIELD NAME="finalisedstatus" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="See \mod_coursework\models\submission::FINALISED_STATUS_FINALISED and related constants for possible values. If equals FINALISED_STATUS_FINALISED, student can no longer add files."/>
         <FIELD NAME="manualsrscode" TYPE="char" LENGTH="50" NOTNULL="true" SEQUENCE="false" COMMENT="Temporary solution for KCL requirement for a student to be able to manually enter their SRS number."/>
         <FIELD NAME="createdby" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="User id of creator"/>
         <FIELD NAME="lastupdatedby" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="User id of last person to update this submission."/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -2484,6 +2484,22 @@ function xmldb_coursework_upgrade($oldversion) {
         // Coursework savepoint reached.
         upgrade_mod_savepoint(true, 2025100302, 'coursework');
     }
+
+    if ($oldversion < 2025110300) {
+
+        // Rename field finalised on table coursework_submissions to finalisedstatus.
+        $table = new xmldb_table('coursework_submissions');
+        $field = new xmldb_field('finalised', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '0', 'timemodified');
+
+        if ($dbman->field_exists($table, $field)) {
+            // Launch rename field finalisedstatus.
+            $dbman->rename_field($table, $field, 'finalisedstatus');
+        }
+
+        // Coursework savepoint reached.
+        upgrade_mod_savepoint(true, 2025110300, 'coursework');
+    }
+
     // Always needs to return true.
     return true;
 }

--- a/lib.php
+++ b/lib.php
@@ -1073,7 +1073,7 @@ function coursework_send_deadline_changed_emails($eventdata) {
             continue;
         }
 
-        $hassubmitted = ($submission && !$submission->finalised);
+        $hassubmitted = ($submission && $submission->finalisedstatus != submission::FINALISED_STATUS_FINALISED);
         $userreleasedate = $coursework->get_student_feedback_release_date();
 
         if ($userreleasedate < time()) {

--- a/lib.php
+++ b/lib.php
@@ -1073,7 +1073,7 @@ function coursework_send_deadline_changed_emails($eventdata) {
             continue;
         }
 
-        $hassubmitted = ($submission && $submission->finalisedstatus != submission::FINALISED_STATUS_FINALISED);
+        $hassubmitted = ($submission && !$submission->is_finalised());
         $userreleasedate = $coursework->get_student_feedback_release_date();
 
         if ($userreleasedate < time()) {

--- a/renderers/object_renderer.php
+++ b/renderers/object_renderer.php
@@ -1292,7 +1292,7 @@ class mod_coursework_object_renderer extends plugin_renderer_base {
         $viewurl = '/mod/coursework/view.php';
         $submissions = $coursework->get_all_submissions();
         $hasfinalised = $coursework->get_finalised_submissions();
-        $finalised = submission::$pool[$coursework->id]['finalised'][1] ?? [];
+        $finalised = submission::$pool[$coursework->id]['finalisedstatus'][submission::FINALISED_STATUS_FINALISED] ?? [];
         $can = fn(string $cap) => has_capability($cap, $this->page->context);
         $canmark = !empty($submissions) && $hasfinalised;
 
@@ -1415,7 +1415,7 @@ class mod_coursework_object_renderer extends plugin_renderer_base {
 
             $submission = submission::find($sub);
 
-            if (empty($submission->finalised)) {
+            if ($submission->finalisedstatus != submission::FINALISED_STATUS_FINALISED) {
                 unset($submissions[$sub->id]);
             }
         }

--- a/renderers/object_renderer.php
+++ b/renderers/object_renderer.php
@@ -1415,7 +1415,7 @@ class mod_coursework_object_renderer extends plugin_renderer_base {
 
             $submission = submission::find($sub);
 
-            if ($submission->finalisedstatus != submission::FINALISED_STATUS_FINALISED) {
+            if (!$submission->is_finalised()) {
                 unset($submissions[$sub->id]);
             }
         }

--- a/templates/submissions/tr/actions.mustache
+++ b/templates/submissions/tr/actions.mustache
@@ -4,7 +4,7 @@
 
     <button class="btn btn-outline-secondary btn-icon rounded-circle"
             type="button" data-toggle="dropdown"
-            aria-haspopup="true" aria-expanded="false">
+            aria-haspopup="true" aria-expanded="false" title="{{#str}}actions{{/str}}">
             <i class="fa-solid fa-ellipsis-vertical"></i>
             <span class="sr-only">{{#str}} actions, mod_coursework {{/str}}</span>
     </button>

--- a/tests/behat/behat_mod_coursework.php
+++ b/tests/behat/behat_mod_coursework.php
@@ -2693,10 +2693,10 @@ class behat_mod_coursework extends behat_base {
     public function the_submission_should_be_finalised($negate = false) {
         global $DB;
 
-        $finalised = $DB->get_field('coursework_submissions', 'finalised', ['id' => $this->submission->id]);
-        if ($negate && $finalised == 1) {
+        $finalised = $DB->get_field('coursework_submissions', 'finalisedstatus', ['id' => $this->submission->id]);
+        if ($negate && $finalised == submission::FINALISED_STATUS_FINALISED) {
             throw new ExpectationException('Submission is finalised and should not be', $this->getSession());
-        } else if (!$negate && $finalised == 0) {
+        } else if (!$negate && $finalised != submission::FINALISED_STATUS_FINALISED) {
             throw new ExpectationException('Submission is not finalised and should be', $this->getSession());
         }
     }
@@ -2717,10 +2717,11 @@ class behat_mod_coursework extends behat_base {
     }
 
     /**
-     * @Given /^the submission is finalised$/
+     * @Given /^the submission is (not )?finalised$/
      */
-    public function the_submission_is_finalised() {
-        $this->submission->finalised = 1;
+    public function the_submission_is_finalised($negate = false) {
+        $this->submission->finalisedstatus = $negate
+            ? submission::FINALISED_STATUS_NOT_FINALISED : submission::FINALISED_STATUS_FINALISED;
         $this->submission->save();
     }
 

--- a/tests/behat/deadline_extension.feature
+++ b/tests/behat/deadline_extension.feature
@@ -1,4 +1,4 @@
-@mod @mod_coursework @RVC_PT_83106618 @mod_coursework_deadline_extension @javascript
+@mod @mod_coursework @RVC_PT_83106618 @mod_coursework_deadline_extension
 Feature: Deadlines extensions for submissions
 
   As an OCM admin
@@ -33,7 +33,9 @@ Feature: Deadlines extensions for submissions
     And I log in as a manager
     And I visit the coursework page
     And I press "Actions"
-    And I follow "Submission extension"
+    And I wait until the page is ready
+    And I click on "Submission extension" "link"
+    And I wait until the page is ready
     And I set the following fields to these values:
       | extended_deadline[day]    | 1       |
       | extended_deadline[month]  | January |
@@ -52,7 +54,9 @@ Feature: Deadlines extensions for submissions
     And I log in as a manager
     And I visit the coursework page
     And I press "Actions"
-    And I follow "Submission extension"
+    And I wait until the page is ready
+    And I click on "Submission extension" "link"
+    And I wait until the page is ready
     And I set the following fields to these values:
       | extended_deadline[day]    | 1       |
       | extended_deadline[month]  | January |

--- a/tests/behat/deadline_extension.feature
+++ b/tests/behat/deadline_extension.feature
@@ -1,4 +1,4 @@
-@mod @mod_coursework @RVC_PT_83106618 @mod_coursework_deadline_extension
+@mod @mod_coursework @RVC_PT_83106618 @mod_coursework_deadline_extension @javascript
 Feature: Deadlines extensions for submissions
 
   As an OCM admin

--- a/tests/behat/export_upload_links.feature
+++ b/tests/behat/export_upload_links.feature
@@ -1,4 +1,4 @@
-@mod @mod_coursework
+@mod @mod_coursework  @mod_coursework_export_upload_links
 Feature: Download and upload buttons on submissions page
   These should only appear when there are submissions
   They should contain the expected menu items corresponding the user's role
@@ -33,6 +33,7 @@ Feature: Download and upload buttons on submissions page
     And I log in as a teacher
     And I visit the coursework page
     And I click on "Download" "button"
+    And I wait until the page is ready
     Then I should see "Download submitted files"
     And I should see "Download grading sheet"
     But I should not see "Download grades"
@@ -44,6 +45,7 @@ Feature: Download and upload buttons on submissions page
     And I log in as "admin"
     And I visit the coursework page
     And I click on "Download" "button"
+    And I wait until the page is ready
     Then I should see "Download submitted files"
     And I should see "Download grades"
     And I should see "Download grading sheet"

--- a/tests/behat/factory.feature
+++ b/tests/behat/factory.feature
@@ -1,21 +1,21 @@
 @mod @mod_coursework @mod_coursework_factory
 Feature: Testing that the factories for behat steps work. If any tests fail, fix this FIRST.
-
     As a developer maintaining the coursework module
     I want to be able to use a factory to generate the scenario context
     So that my tests are easier to write and run faster
 
-  Scenario: Making a coursework
+  Background:
     Given there is a course
-    And I am logged in as a teacher
+
+  Scenario: Making a coursework
+    Given I am logged in as a teacher
     And there is a coursework
     When I visit the coursework page
     Then I should see the title of the coursework on the page
     And I should see the description of the coursework on the page
 
   Scenario: the submission factory works properly and shows the file on the page
-    Given there is a course
-    And there is a coursework
+    Given there is a coursework
     And I am logged in as a student
     And I have a submission
     When I visit the coursework page
@@ -23,8 +23,7 @@ Feature: Testing that the factories for behat steps work. If any tests fail, fix
 
   @javascript
   Scenario: the submission factory works properly and shows the file in the upload area
-    Given there is a course
-    And there is a coursework
+    Given there is a coursework
     And I am logged in as a student
     And I have a submission
     When I visit the coursework page
@@ -32,8 +31,7 @@ Feature: Testing that the factories for behat steps work. If any tests fail, fix
     Then I should see "1" elements in "Upload a file" filemanager
 
   Scenario: Making a coursework sets the defaults correctly
-    Given there is a course
-    And I am logged in as an editing teacher
+    Given I am logged in as an editing teacher
     When I visit the course page
     And I turn editing mode on
     When I add a "coursework" activity to course "C1" section "3" and I fill the form with:
@@ -42,16 +40,14 @@ Feature: Testing that the factories for behat steps work. If any tests fail, fix
     Then the coursework general feedback should be disabled
 
   Scenario: The coursework settings can be changed
-    Given there is a course
-    And I am logged in as an editing teacher
+    Given I am logged in as an editing teacher
     And there is a coursework
     And the coursework "blindmarking" setting is "1" in the database
     When I visit the coursework settings page
     Then the field "blindmarking" matches value "1"
 
   Scenario: disabling general feedback alters the db setting (checkboxes bug is fixed - 0 was being interpreted as 1)
-    Given there is a course
-    And I am logged in as an editing teacher
+    Given I am logged in as an editing teacher
     When I visit the course page
     And I turn editing mode on
     When I add a "coursework" activity to course "C1" section "3" and I fill the form with:
@@ -61,24 +57,20 @@ Feature: Testing that the factories for behat steps work. If any tests fail, fix
     Then the coursework "blindmarking" setting should be "0" in the database
 
   Scenario: logged in as a teacher works
-    Given there is a course
-    And I am logged in as a teacher
+    Given I am logged in as a teacher
     When I visit the course page
     Then I should be on the course page
 
   Scenario: logged in as a manager works
-    Given there is a course
-    And I am logged in as a manager
+    Given I am logged in as a manager
     When I visit the course page
     Then I should be on the course page
 
   Scenario: logged in as a manager works when a student has been created
-    Given there is a course
-    And there is a student
+    Given there is a student
     Then I am logged in as a manager
 
   Scenario: Making a setting NULL
-    Given there is a course
-    And there is a coursework
+    Given there is a coursework
     And the coursework "individualfeedback" setting is "NULL" in the database
     Then the coursework "blindmarking" setting should be "0" in the database

--- a/tests/behat/submission_unfinalise.feature
+++ b/tests/behat/submission_unfinalise.feature
@@ -1,0 +1,74 @@
+@mod @mod_coursework @mod_coursework_submission_unfinalise @javascript
+Feature: Auto finalising before cron runs
+
+  As a manager
+  I want to be able to unfinalise a student's submission after the deadline has passed
+  if the coursework allows late submissions
+  to enable the student to resubmit a different document
+
+  Background:
+    Given there is a course
+    And there is a coursework
+    And the coursework "allowlatesubmissions" setting is "1" in the database
+    And there is a student
+    And there is a teacher
+    And there is another teacher
+    And the student has a submission
+    And the submission deadline has passed
+
+  Scenario: Student visits the coursework page and sees the submission is finalised and cannot edit
+    Given I log in as a student
+    And I visit the coursework page
+    And I should see "Submitted"
+    # So far the submission has not been unfinalised so I cannot edit as student.
+    And I should not see "Edit your submission"
+
+  Scenario: Teacher *cannot unfinalise* when visits the coursework page and sees the submission is finalised when the deadline has passed.
+    When I am logged in as a teacher
+    And I visit the coursework page
+    # I am not able to see the actions button so cannot click "Unfinalise submission".
+    And I should not see "Actions" in the table row containing "student student1"
+    And I should not see "Unfinalise submission"
+
+  Scenario: Manager *can unfinalise* when visits the page and sees the submission is finalised when the deadline has passed.
+    When I am logged in as a manager
+    And I visit the coursework page
+    # The submission is finalised at this point so the submission will not say "Draft".
+    And I should not see "Draft" in the table row containing "student student1"
+    And I click on "Actions" "button"
+    And I click on "Unfinalise submission" "link"
+    And I should see "Are you sure you want to unfinalise the submission for student student1?"
+    And I click on "Yes" "button"
+    And I wait until the page is ready
+    # The submission is now unfinalised so will say "Draft".
+    And I should see "Draft" in the table row containing "student student1"
+    And I log out
+
+
+    And I log in as a student
+    And I visit the coursework page
+    And I should see "Submitted"
+    # Now the submission has been unfinalised so I can edit as student.
+    And I should see "Edit your submission"
+    And I click on "Edit your submission" "link"
+    And I click on "Submit" "button"
+    # Now it is finalised again, so I can no longer edit it.
+    And I should see "Submitted"
+    And I should not see "Edit your submission"
+    And I log out
+
+    When I am logged in as a manager
+    And I visit the coursework page
+    # The submission is now finalised again (by the student) so will not say "Draft".
+    And I should not see "Draft" in the table row containing "student student1"
+
+  Scenario: Manager *cannot unfinalise* when visits the page and sees the submission is finalised when the deadline has passed and activity does not allow late submissions.
+    When I am logged in as a manager
+    And the coursework "allowlatesubmissions" setting is "0" in the database
+    And I visit the coursework page
+    # The submission is finalised at this point (so the submission will not say "Draft").
+    And I should not see "Draft" in the table row containing "student student1"
+    # Because late submissions are not allowed, I cannot unfinalise.
+    And I should not see "Actions" in the table row containing "student student1"
+    And I log out
+

--- a/tests/behat/submission_unfinalise.feature
+++ b/tests/behat/submission_unfinalise.feature
@@ -1,5 +1,5 @@
 @mod @mod_coursework @mod_coursework_submission_unfinalise @javascript
-Feature: Auto finalising before cron runs
+Feature: Manager manually un-finalising a student submission
 
   As a manager
   I want to be able to unfinalise a student's submission after the deadline has passed
@@ -71,4 +71,3 @@ Feature: Auto finalising before cron runs
     # Because late submissions are not allowed, I cannot unfinalise.
     And I should not see "Actions" in the table row containing "student student1"
     And I log out
-

--- a/tests/behat/submissions_auto_finalisation.feature
+++ b/tests/behat/submissions_auto_finalisation.feature
@@ -1,4 +1,4 @@
-@mod @mod_coursework
+@mod @mod_coursework @mod_coursework_auto_finalisation @javascript
 Feature: Auto finalising before cron runs
 
     As a teacher
@@ -11,11 +11,12 @@ Feature: Auto finalising before cron runs
     And there is a coursework
     And there is a student
     And the student has a submission
+    And the submission is not finalised
 
   Scenario: Teacher visits the page and sees the submission is finalised when the deadline has passed
     Given I am logged in as a teacher
     And I visit the coursework page
-    Then I should not see "Add feedback"
+    Then I should not see "Add feedback" in the table row containing "student student1"
     And the coursework deadline has passed
     When I reload the page
-    Then I should see "Add feedback"
+    Then I should see "Add feedback" in the table row containing "student student1"

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -233,7 +233,7 @@ class mod_coursework_generator extends testing_module_generator {
         if (!isset($submission->timemodified)) {
             $submission->timemodified = time();
         }
-        $submission->finalised = !empty($submission->finalised) ? 1 : 0;
+        $submission->finalisedstatus = submission::FINALISED_STATUS_FINALISED;
 
         $submission->save();
 

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -233,7 +233,7 @@ class mod_coursework_generator extends testing_module_generator {
         if (!isset($submission->timemodified)) {
             $submission->timemodified = time();
         }
-        $submission->finalisedstatus = submission::FINALISED_STATUS_FINALISED;
+        $submission->finalisedstatus = $submission->finalisedstatus ?: submission::FINALISED_STATUS_NOT_FINALISED;
 
         $submission->save();
 

--- a/tests/phpunit/cron_test.php
+++ b/tests/phpunit/cron_test.php
@@ -63,7 +63,7 @@ final class cron_test extends \advanced_testcase {
 
         // Then the submission should be finalised.
         $submission->reload();
-        $this->assertEquals(submission::FINALISED_STATUS_FINALISED, $submission->finalisedstatus);
+        $this->assertTrue($submission->is_finalised());
     }
 
     public function test_cron_does_not_auto_finalise_before_deadline(): void {
@@ -87,7 +87,7 @@ final class cron_test extends \advanced_testcase {
 
         // Then the submission should be finalised.
         $submission->reload();
-        $this->assertEquals(submission::FINALISED_STATUS_NOT_FINALISED, $submission->finalisedstatus);
+        $this->assertFalse($submission->is_finalised());
     }
 
     public function test_admins_and_graders(): void {

--- a/tests/phpunit/cron_test.php
+++ b/tests/phpunit/cron_test.php
@@ -63,7 +63,7 @@ final class cron_test extends \advanced_testcase {
 
         // Then the submission should be finalised.
         $submission->reload();
-        $this->assertEquals(1, $submission->finalised);
+        $this->assertEquals(submission::FINALISED_STATUS_FINALISED, $submission->finalisedstatus);
     }
 
     public function test_cron_does_not_auto_finalise_before_deadline(): void {
@@ -87,7 +87,7 @@ final class cron_test extends \advanced_testcase {
 
         // Then the submission should be finalised.
         $submission->reload();
-        $this->assertEquals(0, $submission->finalised);
+        $this->assertEquals(submission::FINALISED_STATUS_NOT_FINALISED, $submission->finalisedstatus);
     }
 
     public function test_admins_and_graders(): void {
@@ -104,7 +104,7 @@ final class cron_test extends \advanced_testcase {
         $coursework = $this->create_a_coursework();
         $this->create_a_student();
         $submission = $this->create_a_submission_for_the_student();
-        $submission->update_attribute('finalised', 0);
+        $submission->update_attribute('finalisedstatus', submission::FINALISED_STATUS_NOT_FINALISED);
         $coursework->update_attribute('deadline', strtotime('-1 week'));
         $submission->update_attribute('timesubmitted', 5555);
 
@@ -118,7 +118,7 @@ final class cron_test extends \advanced_testcase {
         $coursework = $this->create_a_coursework();
         $this->create_a_student();
         $submission = $this->create_a_submission_for_the_student();
-        $submission->update_attribute('finalised', 1);
+        $submission->update_attribute('finalisedstatus', submission::FINALISED_STATUS_FINALISED);
         $coursework->update_attribute('deadline', strtotime('-1 week'));
         $coursework->update_attribute('individualfeedback', strtotime('-1 week'));
         $submission->update_attribute('timesubmitted', 5555);
@@ -133,7 +133,7 @@ final class cron_test extends \advanced_testcase {
         $coursework = $this->create_a_coursework();
         $this->create_a_student();
         $submission = $this->create_a_submission_for_the_student();
-        $submission->update_attribute('finalised', 1);
+        $submission->update_attribute('finalisedstatus', submission::FINALISED_STATUS_FINALISED);
         $coursework->update_attribute('individualfeedback', strtotime('+1 week'));
 
         \mod_coursework\cron::run();
@@ -146,7 +146,7 @@ final class cron_test extends \advanced_testcase {
         $coursework = $this->create_a_coursework();
         $this->create_a_student();
         $submission = $this->create_a_submission_for_the_student();
-        $submission->update_attribute('finalised', 1);
+        $submission->update_attribute('finalisedstatus', submission::FINALISED_STATUS_FINALISED);
         $this->create_a_final_feedback_for_the_submission();
         $coursework->update_attribute('individualfeedback', strtotime('-1 week'));
 

--- a/tests/phpunit/models/coursework_test.php
+++ b/tests/phpunit/models/coursework_test.php
@@ -271,7 +271,7 @@ final class coursework_test extends \advanced_testcase {
         $submission->update_attribute('courseworkid', 54443434);
         $coursework->update_attribute('deadline', strtotime('1 week ago'));
         $coursework->finalise_all();
-        $this->assertEquals(submission::FINALISED_STATUS_NOT_FINALISED, $submission->reload()->finalisedstatus);
+        $this->assertFalse($submission->reload()->is_finalised());
     }
 
     public function test_finalise_all_works(): void {
@@ -279,7 +279,7 @@ final class coursework_test extends \advanced_testcase {
         $submission = $this->create_a_submission_for_the_student();
         $coursework->update_attribute('deadline', strtotime('1 week ago'));
         $coursework->finalise_all();
-        $this->assertEquals(submission::FINALISED_STATUS_FINALISED, $submission->reload()->finalisedstatus);
+        $this->assertTrue($submission->reload()->is_finalised());
     }
 
     public function test_deadline_has_passed_when_it_has(): void {

--- a/tests/phpunit/models/coursework_test.php
+++ b/tests/phpunit/models/coursework_test.php
@@ -25,6 +25,7 @@
 namespace mod_coursework;
 
 use mod_coursework\models\coursework;
+use mod_coursework\models\submission;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -270,7 +271,7 @@ final class coursework_test extends \advanced_testcase {
         $submission->update_attribute('courseworkid', 54443434);
         $coursework->update_attribute('deadline', strtotime('1 week ago'));
         $coursework->finalise_all();
-        $this->assertEquals(0, $submission->reload()->finalised);
+        $this->assertEquals(submission::FINALISED_STATUS_NOT_FINALISED, $submission->reload()->finalisedstatus);
     }
 
     public function test_finalise_all_works(): void {
@@ -278,7 +279,7 @@ final class coursework_test extends \advanced_testcase {
         $submission = $this->create_a_submission_for_the_student();
         $coursework->update_attribute('deadline', strtotime('1 week ago'));
         $coursework->finalise_all();
-        $this->assertEquals(1, $submission->reload()->finalised);
+        $this->assertEquals(submission::FINALISED_STATUS_FINALISED, $submission->reload()->finalisedstatus);
     }
 
     public function test_deadline_has_passed_when_it_has(): void {

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_coursework';
 
-$plugin->version = 2025100302;  // If version == 0 then module will not be installed.
+$plugin->version = 2025110300;  // If version == 0 then module will not be installed.
 $plugin->requires = 2024100100;  // Requires this Moodle version.
 
 $plugin->cron = 300;        // Period for cron to check this module (secs).

--- a/view.php
+++ b/view.php
@@ -250,6 +250,9 @@ if ($coursemoduleid) {
     }
 }
 
+// This will set $PAGE->context to the coursemodule's context.
+require_login($course, true, $coursemodule);
+
 $coursework = mod_coursework\models\coursework::find($courseworkrecord);
 
 // Check if group is in session and use it no group available in url
@@ -266,9 +269,6 @@ if (($coursework->blindmarking && !$viewanonymous )) {
 
 // Make sure we sort out any stuff that cron should have done, just in case it's not run yet.
 $coursework->finalise_all();
-
-// This will set $PAGE->context to the coursemodule's context.
-require_login($course, true, $coursemodule);
 
 // Name of new zip file.
 $filename = str_replace(' ', '_', clean_filename($COURSE->shortname . '-' . $coursework->name . '.zip'));


### PR DESCRIPTION
- Gives managers the ability to manually unfinalise a submission after the deadline where late submissions are allowed, to permit the student to go back in to a previous submission and re-upload a new file / re-finalise it
- to do this, renames the existing mdl_coursework_submissions.finalised field to finalisedstatus, and introduces a new possible value for that field (was 0 = not finalised, 1 = finalised, now can be 2 = manually unfinalised
- where value is manually unfinalised, the submission will not be automatically finalised by cron or on page view - must be finalised by manual user action (student or manager)
- introduces constants to clarify what is happening e.g. const FINALISED_STATUS_MANUALLY_UNFINALISED = 2;
- includes behat tests which are passing