### PR TITLE
CTP-5392: added subplugintypes declaration

### DIFF
--- a/db/subplugins.json
+++ b/db/subplugins.json
@@ -1,5 +1,8 @@
 {
   "plugintypes" : {
-    "courseworkcandidateprovider" : "mod\/coursework\/candidateprovider"
+    "courseworkcandidateprovider" : "mod/coursework/candidateprovider"
+  },
+  "subplugintypes" : {
+    "courseworkcandidateprovider" : "candidateprovider"
   }
 }


### PR DESCRIPTION
Moodle 5.1+ requires explicit declaration of subplugintypes.
It should be compatible with Moodle 4.5.