### PR TITLE
CTP-5437 Hide profile pictures for blind marking

### DIFF
--- a/tests/behat/behat_mod_coursework.php
+++ b/tests/behat/behat_mod_coursework.php
@@ -708,25 +708,41 @@ class behat_mod_coursework extends behat_base {
     }
 
     /**
-     * @Then /^I should not see the student's name in the user cell$/
+     * @Then /^I should( not)? see the student's name in the user cell$/
+     *
+     * @param bool $negate
      */
-    public function i_should_not_see_the_students_name_in_the_user_cell() {
+    public function i_should_see_the_students_name_in_the_user_cell(bool $negate = false) {
         /**
          * @var $page mod_coursework_behat_single_grading_interface
          */
         $page = $this->get_page('single grading interface');
-        $page->should_not_have_user_name_in_user_cell($this->student);
+        $found = $page->should_have_user_name_in_user_cell($this->student);
+
+        if ($negate && $found) {
+            throw new ExpectationException('User name unexpectedly found in cell', $this->getsession());
+        } else if (!$negate && !$found) {
+            throw new ExpectationException('User name not found in cell', $this->getsession());
+        }
     }
 
     /**
-     * @Then /^I should see the student's name in the user cell$/
+     * @Then /^I should( not)? see the student's picture in the user cell$/
+     *
+     * @param bool $negate
      */
-    public function i_should_see_the_students_name_in_the_user_cell() {
+    public function i_should_see_the_students_picture_in_the_user_cell($negate = false) {
         /**
          * @var $page mod_coursework_behat_single_grading_interface
          */
         $page = $this->get_page('single grading interface');
-        $page->should_have_user_name_in_user_cell($this->student);
+        $found = $page->should_have_user_picture_in_user_cell();
+
+        if ($negate && $found) {
+            throw new ExpectationException('User picture unexpectedly found in cell', $this->getsession());
+        } else if (!$negate && !$found) {
+            throw new ExpectationException('User picture not found in cell', $this->getsession());
+        }
     }
 
     /**

--- a/tests/behat/blind_marking_visibility_for_teachers_with_blind_marking.feature
+++ b/tests/behat/blind_marking_visibility_for_teachers_with_blind_marking.feature
@@ -8,16 +8,25 @@ Feature: Visibility for teachers with blind marking
   Background:
     Given there is a course
     And there is a coursework
-    And blind marking is enabled
 
   Scenario: The student names are hidden from teachers in the user cells
-    Given I am logged in as a teacher
+    Given blind marking is enabled
+    And I am logged in as a teacher
     And there is a student
     When I visit the coursework page
     Then I should not see the student's name in the user cell
+    And I should not see the student's picture in the user cell
+
+  Scenario: The student names are not hidden from teachers in the user cells
+    Given I am logged in as a teacher
+    And there is a student
+    When I visit the coursework page
+    Then I should see the student's name in the user cell
+    And I should see the student's picture in the user cell
 
   Scenario: The user names are hidden from teachers in the group cells
-    Given I am logged in as a teacher
+    Given blind marking is enabled
+    And I am logged in as a teacher
     And there is a student
     And group submissions are enabled
     And the student is a member of a group
@@ -26,7 +35,8 @@ Feature: Visibility for teachers with blind marking
     Then I should not see the student's name in the group cell
 
   Scenario: Teachers cannot see other initial grades before final grading happens
-    Given the coursework "numberofmarkers" setting is "2" in the database
+    Given blind marking is enabled
+    And the coursework "numberofmarkers" setting is "2" in the database
     And there is a teacher
     And there is another teacher
     And there is a student

--- a/tests/behat/pages/single_grading_interface.php
+++ b/tests/behat/pages/single_grading_interface.php
@@ -103,17 +103,17 @@ class mod_coursework_behat_single_grading_interface extends mod_coursework_behat
     /**
      * @param allocatable $student
      */
-    public function should_not_have_user_name_in_user_cell($student) {
-        $css = '.user_cell';
-        $this->should_not_have_css($css, $student->name());
+    public function should_have_user_name_in_user_cell($student) {
+        $studentname = $student->name();
+        $xpath = "//td[@class='mod-coursework-submissions-user-col']//a[normalize-space(string()) = '$studentname']";
+        return $this->getpage()->find('xpath', $xpath) !== null;
     }
 
     /**
-     * @param allocatable $student
      */
-    public function should_have_user_name_in_user_cell($student) {
-        $css = '.user_cell';
-        $this->should_have_css($css, $student->name());
+    public function should_have_user_picture_in_user_cell() {
+        $xpath = "//td[@class='mod-coursework-submissions-user-col']//div[contains(@style,'background-image: url')]";
+        return $this->getpage()->find('xpath', $xpath) !== null;
     }
 
     /**

--- a/tests/behat/plagiarism_flagging_group.feature
+++ b/tests/behat/plagiarism_flagging_group.feature
@@ -1,0 +1,24 @@
+@mod @mod_coursework @javascript
+Feature: Teachers should be able to add and edit plagiarism flags for group submissions
+
+  Background:
+    Given there is a course
+    And there is a coursework
+    And the coursework "plagiarismflagenabled" setting is "1" in the database
+    And the coursework "usegroups" setting is "1" in the database
+    And there is a student
+    And the student is a member of a group
+    And there is a teacher
+    And the group has a submission
+    And the submission is finalised
+
+  Scenario: Teacher can flag a group submission for plagiarism
+    Given I am logged in as a teacher
+    And I visit the coursework page
+    And I should not see "Flagged for plagiarism"
+    And I click on "Actions" "button"
+    And I click on "Plagiarism action" "link"
+    And I set the field "Status" to "Under Investigation"
+    And I set the field "Internal comment" to "Test comment"
+    And I click on "Save" "button"
+    Then I should see "Flagged for plagiarism"


### PR DESCRIPTION
Hide user profile pictures when blind marking enabled (regression in 0199ff8). We add a Behat test to cover this. Previously this tested that a non-existent element was not present. The element selector has been fixed and we now check the user name and picture are present when blind marking = No, but not present when blind marking = Yes.

Also fixed is CTP-5440 (Plagiarism flag not saved for group) by checking the allocatable is a user before getting the user picture when re- rendering the cell following an AJAX update, with the above check for blind marking. Behat test coverage for this is also added.