### PR TITLE
CTP-5470 Fix cron error extension does not exist

### DIFF
--- a/classes/cron.php
+++ b/classes/cron.php
@@ -221,7 +221,7 @@ class cron {
                     $usercounter[$user->id]++;
                 }
 
-                $extension = $user->extension ?? 0;
+                $extension = isset($user->extension) ? $user->extension : 0;
                 $emailreminder = new stdClass();
                 $emailreminder->userid = $user->id;
                 $emailreminder->courseworkid = $user->courseworkid;


### PR DESCRIPTION
Revert a change from 39ecae17 to again use isset() instead of the null coalescing operator since the latter resulted in a call to table_base-> __get() causing the following error when the cron was run:

   Coding error detected, it must be fixed by a programmer: Column
   extension does not exist in class user

Also add a basic PHPUnit test to call send_email_reminders_to_students() which would have detected the above error.