### PR TITLE
CTP-5415 Empty action menu after plagiarism flag

### DIFF
--- a/classes/render_helpers/grading_report/data/actions_cell_data.php
+++ b/classes/render_helpers/grading_report/data/actions_cell_data.php
@@ -230,10 +230,12 @@ class actions_cell_data extends cell_data_base {
 
         $submission = $rowsbase->get_submission();
         $plagiarismflag = $rowsbase->get_plagiarism_flag();
-        $data->plagiarism = new stdClass();
-        $data->plagiarism->url = $this->get_plagiarism_url($submission, $plagiarismflag);
-        $data->plagiarismstatus = $this->get_flagged_plagiarism_status($submission);
-        $data->plagiarism->flagid = $plagiarismflag->id ?? null;
+        if ($url = $this->get_plagiarism_url($submission, $plagiarismflag)) {
+            $data->plagiarism = new stdClass();
+            $data->plagiarism->url = $url;
+            $data->plagiarismstatus = $this->get_flagged_plagiarism_status($submission);
+            $data->plagiarism->flagid = $plagiarismflag->id ?? null;
+        }
     }
 
     /**

--- a/tests/behat/plagiarism_flagging.feature
+++ b/tests/behat/plagiarism_flagging.feature
@@ -15,6 +15,7 @@ Feature: Teachers and course administrators should be able to add and edit
     Given I am logged in as a teacher
     And I visit the coursework page
     And I should not see "Flagged for plagiarism"
+    And "Actions" "button" should exist
     And I click on "Actions" "button"
     And I click on "Plagiarism action" "link"
     And I set the field "Status" to "Under Investigation"
@@ -22,3 +23,4 @@ Feature: Teachers and course administrators should be able to add and edit
     And I click on "Save" "button"
     And I wait until the page is ready
     Then I should see "Flagged for plagiarism"
+    And "Actions" "button" should not exist


### PR DESCRIPTION
By default teachers can add a plagiarism flag (addplagiarismflag = Allow) but not edit these (updateplagiarismflag = Not set).  Previously, after adding a flag they got an empty Actions menu. This change removes the empty Actions menu which maintains functional parity with the old coursework version (64f7e41).

(Possibly it would be desirable to instead allow teachers to edit plagiarism flags they set, in which case we would need to consider whether they can still edit the flag if others have also edited this, and whether a specific capability would be required, for example, updateownplagiarismflag).