### PR TITLE
Ctp 5456 released badge

### DIFF
--- a/classes/render_helpers/grading_report/data/marking_cell_data.php
+++ b/classes/render_helpers/grading_report/data/marking_cell_data.php
@@ -418,7 +418,6 @@ class marking_cell_data extends cell_data_base {
             $markdata = new stdClass();
             $markdata->markvalue = get_string($moderation->agreement, 'coursework');
             $markdata->readyforrelease = $moderation->agreement === 'agreed' && !$submission->is_published();
-            $markdata->released = $submission->is_published();
 
             if ($moderation->timemodified) {
                 $markdata->moderatorname = $moderation->moderator()->name();

--- a/classes/render_helpers/grading_report/data/marking_cell_data.php
+++ b/classes/render_helpers/grading_report/data/marking_cell_data.php
@@ -410,8 +410,12 @@ class marking_cell_data extends cell_data_base {
 
         // Existing moderation.
         if ($moderation) {
-            if (!$this->ability->can('show', $moderation)) {
-                return $moderationdata; // Exit: Cannot view moderation data.
+            $canseeallgrades = $this->ability->can('show', $moderation);
+            if (!$canseeallgrades) {
+                $gradedbyme = $rowsbase->get_single_feedback()->lasteditedbyuser == $USER->id;
+                if (!$gradedbyme) {
+                    return null; // Exit: Cannot view moderation data.
+                }
             }
 
             // Mark data.
@@ -429,12 +433,15 @@ class marking_cell_data extends cell_data_base {
             // It should show what the user is moderating/agreeing on.
             // Ideally this could be combined with the agree feedback process.
 
-            // Default show url.
-            $markdata->url = router::instance()->get_path('show moderation', ['moderation' => $moderation]);
+            if ($canseeallgrades) {
+                // If user can see all grades and/or edit moderations, they may see moderation result as a link.
+                // Default show url.
+                $markdata->url = router::instance()->get_path('show moderation', ['moderation' => $moderation]);
 
-            // Edit url (overwrites default if user can edit).
-            if (!$submission->is_published() && $this->ability->can('edit', $moderation)) {
-                $markdata->url = router::instance()->get_path('edit moderation', ['moderation' => $moderation]);
+                // Edit url (overwrites default if user can edit).
+                if (!$submission->is_published() && $this->ability->can('edit', $moderation)) {
+                    $markdata->url = router::instance()->get_path('edit moderation', ['moderation' => $moderation]);
+                }
             }
 
             $moderationdata->mark = $markdata;

--- a/classes/render_helpers/grading_report/data/submission_cell_data.php
+++ b/classes/render_helpers/grading_report/data/submission_cell_data.php
@@ -73,6 +73,7 @@ class submission_cell_data extends cell_data_base {
         $data->submissiondata = new stdClass();
         $data->submissiondata->files = $this->get_submission_files_data($rowobject);
         $data->submissiondata->finalised = $submission->is_finalised();
+        $data->submissiondata->released = $submission->is_published();
 
         $this->add_plagiarism_data($data->submissiondata, $submission);
         $this->add_late_submission_data($data->submissiondata, $submission);

--- a/templates/submissions/tr/marking.mustache
+++ b/templates/submissions/tr/marking.mustache
@@ -80,7 +80,22 @@
                 {{#str}} draft, mod_coursework {{/str}}
             </span>
             {{/draft}}
-
+            {{#moderation}}
+                {{#mark}}
+                    {{#readyforrelease}}
+                        <span class="badge badge-pill badge-warning">
+                        <i class="fa-solid fa-circle-check my-1 mr-1"></i>
+                            {{#str}} ready_release, mod_coursework {{/str}}</span>
+                    {{/readyforrelease}}
+                {{/mark}}
+                {{! Un-moderated submissions in a moderated coursework may still be released }}
+                {{#submission.submissiondata.released}}
+                    <span class="badge badge-pill badge-success">
+                        <i class="fa-solid fa-circle-check my-1 mr-1"></i>
+                        {{#str}} statusreleased, mod_coursework {{/str}}
+                    </span>
+                {{/submission.submissiondata.released}}
+            {{/moderation}}
             {{#markurl}}
             <a data-mark-action="editfeedback" data-behat-feedbackid="{{feedbackid}}" href="{{{markurl}}}" class="font-weight-bold pl-1">{{{mark}}}</a>
             {{/markurl}}
@@ -178,32 +193,8 @@
                 </div>
             <div class="text-right ml-auto">
                 {{#mark}}
-                    {{#readyforrelease}}
-                        <span class="badge badge-pill badge-warning">
-                        <i class="fa-solid fa-circle-check my-1 mr-1"></i>
-                        {{#str}} ready_release, mod_coursework {{/str}}</span>
-                    {{/readyforrelease}}
-
-                    {{! Released. }}
-                    {{#released}}
-                        <span class="badge badge-pill badge-success">
-                            <i class="fa-solid fa-circle-check my-1 mr-1"></i>
-                            {{#str}} statusreleased, mod_coursework {{/str}}
-                        </span>
-                    {{/released}}
-
                     <a class="ml-1" href="{{{url}}}" data-behat-mark="{{markvalue}}">{{markvalue}}</a>
                 {{/mark}}
-                {{^mark}}
-                {{! Un-moderated submissions may still be released }}
-                    {{#submission.submissiondata.released}}
-                        <span class="badge badge-pill badge-success">
-                            <i class="fa-solid fa-circle-check my-1 mr-1"></i>
-                            {{#str}} statusreleased, mod_coursework {{/str}}
-                        </span>
-                    {{/submission.submissiondata.released}}
-                {{/mark}}
-
                 {{#addmoderation}}
                     <a class="btn btn-sm btn-success" href="{{{url}}}" data-behat-mark-action="addmoderation">{{#str}} agree_marking, mod_coursework {{/str}}</a>
                 {{/addmoderation}}

--- a/templates/submissions/tr/marking.mustache
+++ b/templates/submissions/tr/marking.mustache
@@ -193,7 +193,13 @@
                 </div>
             <div class="text-right ml-auto">
                 {{#mark}}
-                    <a class="ml-1" href="{{{url}}}" data-behat-mark="{{markvalue}}">{{markvalue}}</a>
+                    {{#url}}
+                        <a class="ml-1" href="{{{url}}}" data-behat-mark="{{markvalue}}">{{markvalue}}</a>
+                    {{/url}}
+                    {{^url}}
+                    {{! User can see but not edit/add moderation }}
+                        <span>{{{markvalue}}}</span>
+                    {{/url}}
                 {{/mark}}
                 {{#addmoderation}}
                     <a class="btn btn-sm btn-success" href="{{{url}}}" data-behat-mark-action="addmoderation">{{#str}} agree_marking, mod_coursework {{/str}}</a>

--- a/templates/submissions/tr/marking.mustache
+++ b/templates/submissions/tr/marking.mustache
@@ -194,6 +194,15 @@
 
                     <a class="ml-1" href="{{{url}}}" data-behat-mark="{{markvalue}}">{{markvalue}}</a>
                 {{/mark}}
+                {{^mark}}
+                {{! Un-moderated submissions may still be released }}
+                    {{#submission.submissiondata.released}}
+                        <span class="badge badge-pill badge-success">
+                            <i class="fa-solid fa-circle-check my-1 mr-1"></i>
+                            {{#str}} statusreleased, mod_coursework {{/str}}
+                        </span>
+                    {{/submission.submissiondata.released}}
+                {{/mark}}
 
                 {{#addmoderation}}
                     <a class="btn btn-sm btn-success" href="{{{url}}}" data-behat-mark-action="addmoderation">{{#str}} agree_marking, mod_coursework {{/str}}</a>

--- a/tests/behat/behat_mod_coursework.php
+++ b/tests/behat/behat_mod_coursework.php
@@ -483,6 +483,7 @@ class behat_mod_coursework extends behat_base {
         $feedback = new stdClass();
         $feedback->submissionid = $this->submission->id;
         $feedback->assessorid = $this->teacher->id;
+        $feedback->lasteditedbyuser = $this->teacher->id;
         $feedback->grade = 58;
         $feedback->feedbackcomment = 'Blah';
         $feedback->stageidentifier = 'assessor_1';

--- a/tests/behat/moderation_edit.feature
+++ b/tests/behat/moderation_edit.feature
@@ -1,4 +1,4 @@
-@mod @mod_coursework_moderation_edit
+@mod @mod_coursework @mod_coursework_moderation_edit
 Feature: Moderation of feedback
 
   Scenario: When I moderate feedback then edit the moderation by clicking the pencil button the moderation form should load with no error

--- a/tests/behat/moderation_edit.feature
+++ b/tests/behat/moderation_edit.feature
@@ -1,18 +1,21 @@
-@mod @mod_coursework @javascript
+@mod @mod_coursework_moderation_edit
 Feature: Moderation of feedback
 
   Scenario: When I moderate feedback then edit the moderation by clicking the pencil button the moderation form should load with no error
     Given there is a course
     And there is a coursework
-    And there is a student
+    And there is a student called "John1"
     And there is a teacher
     And the coursework "numberofmarkers" setting is "1" in the database
     And the coursework "moderationagreementenabled" setting is "1" in the database
     And the student has a submission
-    And there is feedback for the submission from the teacher
+    And the submission is finalised
+    And there is finalised feedback for the submission from the teacher
     And I log in as "admin"
     And I visit the coursework page
-    And I click on "Moderate" "link"
+    And I click on "Agree marking" "link"
+    And I set the field "Moderation agreement" to "Agreed"
     And I click on "Save changes" "button"
-    When I click the edit moderation agreement link
-    Then I should see "Moderation agreement"
+    Then I should see "Moderation"
+    And I should see "Agreed" in the table row containing "John1"
+    And I should not see "Disagreed" in the table row containing "John1"

--- a/tests/behat/moderation_view.feature
+++ b/tests/behat/moderation_view.feature
@@ -1,24 +1,24 @@
-@mod @mod_coursework @javascript
+@mod @mod_coursework @mod_coursework_moderation_view
 Feature: View moderation feedback
 
   Scenario: As an assessor I’ve received some moderation and when I view this I should see the moderator's feedback with no error
     Given there is a course
     And there is a coursework
-    And there is a student
+    And there is a student called "John1"
     And there is a teacher
-    And the following "permission overrides" exist:
-      | capability                             | permission | role    | contextlevel | reference |
-      | mod/coursework:viewallgradesatalltimes | Allow      | teacher | Course       | C1        |
     And the coursework "numberofmarkers" setting is "1" in the database
     And the coursework "moderationagreementenabled" setting is "1" in the database
     And the student has a submission
-    And there is feedback for the submission from the teacher
+    And the submission is finalised
+    And there is finalised feedback for the submission from the teacher
     And I log in as "admin"
     And I visit the coursework page
-    And I click on "Moderate" "link"
+    And I click on "Agree marking" "link"
+    And I set the field "Moderation agreement" to "Agreed"
     And I click on "Save changes" "button"
     And I log out
     And I log in as the teacher
     And I visit the coursework page
-    When I click on "View moderation" "link"
-    Then I should see "Moderation for student"
+    Then I should see "Moderation" in the table row containing "John1"
+    And I should see "Agreed" in the table row containing "John1"
+    And I should not see "Disagreed" in the table row containing "John1"


### PR DESCRIPTION
PR includes fixes for 3 JIRA tickets (numbers in commit messages) as they are related and all quite minor:

- CTP-5456 "Released" flag not always shown with moderated courseworks
- CTP-5455 Move "Released" flag location in UI
- CTP-5411 Show moderation status (not editable) to graders

Also reinstates, fixes and improves previous moderation behat tests