### PR TITLE
Ctp 5490 persisted

### DIFF
--- a/classes/allocation/upload.php
+++ b/classes/allocation/upload.php
@@ -127,15 +127,10 @@ class upload {
 
                     // check if allocatable exists in this coursework
                     $allocatableid = $allocatable ? $allocatable->id() : null;
-                    $allocatablefound = $allocatableid
-                        && !empty(
-                            array_filter($allocatables, function ($a) use ($allocatableid) {
-                                return $a->id() == $allocatableid;
-                            })
-                        );
-                    if (!$allocatablefound) {
+                    $allocatableincoursework = $allocatableid ? $allocatables[$allocatableid] : null;
+                    if (!$allocatableincoursework) {
                         // E.g. string key 'usernotincoursework'.
-                        $errors[$s] = get_string($allocatabletype . 'notincoursework', 'coursework', $value) . $assessoridentifier;
+                        $errors[$s] = get_string($allocatabletype . 'notincoursework', 'coursework', $value);
                         break;
                     }
                     // duplicate user or group

--- a/classes/allocation/upload.php
+++ b/classes/allocation/upload.php
@@ -126,17 +126,24 @@ class upload {
                     }
 
                     // check if allocatable exists in this coursework
-                    if (!$allocatable || !in_array($allocatable->id, $allocatables)) {
+                    $allocatableid = $allocatable ? $allocatable->id() : null;
+                    $allocatablefound = $allocatableid
+                        && !empty(
+                            array_filter($allocatables, function ($a) use ($allocatableid) {
+                                return $a->id() == $allocatableid;
+                            })
+                        );
+                    if (!$allocatablefound) {
                         // E.g. string key 'usernotincoursework'.
                         $errors[$s] = get_string($allocatabletype . 'notincoursework', 'coursework', $value) . $assessoridentifier;
                         break;
                     }
                     // duplicate user or group
-                    if ($allocatable && in_array($allocatable->id, $allocatablesinfile)) {
+                    if ($allocatable && in_array($allocatableid, $allocatablesinfile)) {
                         $errors[$s] = get_string('duplicate' . $allocatabletype, 'coursework', $value);
                         break;
                     }
-                    $allocatablesinfile[] = $allocatable->id;
+                    $allocatablesinfile[] = $allocatableid;
                 }
 
                 // validate assessor if exists in the coursework and has one of the capabilities allowing them to grade

--- a/classes/calendar.php
+++ b/classes/calendar.php
@@ -26,6 +26,7 @@ namespace mod_coursework;
 use calendar_event;
 use dml_exception;
 use stdClass;
+use mod_coursework\models\coursework;
 
 /**
  * Class to handle interaction with core calendar.
@@ -35,13 +36,13 @@ use stdClass;
 class calendar {
     /**
      * Get an object to create a calendar event for coursework.
-     * @param object $coursework
+     * @param coursework $coursework
      * @param string $eventtype
      * @param int|null $deadline
      * @return stdClass
      * @throws \coding_exception
      */
-    public static function coursework_event(object $coursework, string $eventtype, ?int $deadline): stdClass {
+    public static function coursework_event(coursework $coursework, string $eventtype, ?int $deadline): stdClass {
 
         $event = new stdClass();
         $event->type = CALENDAR_EVENT_TYPE_ACTION;
@@ -55,7 +56,7 @@ class calendar {
             $intro = $coursework->intro;
         }
 
-        $cm = get_coursemodule_from_instance('coursework', $coursework->id);
+        $cm = $coursework->get_course_module();
 
         // We need to remove the links to files as the calendar is not ready
         // to support module events with file areas.

--- a/classes/framework/table_base.php
+++ b/classes/framework/table_base.php
@@ -24,7 +24,8 @@ namespace mod_coursework\framework;
 
 use AllowDynamicProperties;
 use cache;
-use coding_exception;
+use core\exception\coding_exception;
+use core\exception\invalid_parameter_exception;
 use dml_exception;
 use dml_missing_record_exception;
 use dml_multiple_records_exception;
@@ -57,9 +58,11 @@ abstract class table_base {
     private $dataloaded = false;
 
     /**
+     * The database record ID.
+     * Protected and readonly because we only want this to be set from within this class from DB record.
      * @var int
      */
-    public $id;
+    protected readonly int $id;
 
     /**
      * Makes a new instance. Can be overridden to provide a factory
@@ -67,10 +70,9 @@ abstract class table_base {
      * @param stdClass|int|array $dbrecord
      * @param bool $reload
      * @return bool|self
-     * @throws coding_exception
-     * @throws dml_exception
+     * @throws dml_exception|invalid_parameter_exception
      */
-    public static function find($dbrecord, $reload = true) {
+    public static function find($dbrecord, $reload = true): self|bool {
 
         global $DB;
 
@@ -88,26 +90,64 @@ abstract class table_base {
             return new $klass($data);
         }
 
+        $recordid = self::get_id_from_record($dbrecord);
+        // Cast to array in case it's stdClass.
         $dbrecord = (array)$dbrecord;
+        if (!$recordid && $reload) {
+            // Supplied data without record ID - treat as query params and try to get full record.
+            // Filter to valid DB table columns.
+            $allowedkeys = array_keys($DB->get_columns(static::$tablename));
+            $filteredparams = [];
+            foreach (array_keys($dbrecord) as $key) {
+                if (in_array($key, $allowedkeys)) {
+                    $filteredparams[$key] = $dbrecord[$key];
+                }
+            }
+            if (empty($filteredparams)) {
+                throw new coding_exception("No valid fields from table " . static::$tablename . " in params " . json_encode($dbrecord));
+            }
 
-        // Supplied a partial DB stdClass record
-        if (!array_key_exists('id', $dbrecord)) {
-            $dbrecord = $DB->get_record(static::get_table_name(), $dbrecord);
+            $dbrecords = $DB->get_records(static::get_table_name(), $filteredparams, '', '*', 0, 2);
+            if (count($dbrecords) > 1) {
+                throw new invalid_parameter_exception("Found multiple records with supplied properties " . json_encode($dbrecord) . "||" . json_encode($dbrecords));
+            }
+            if (!$dbrecords) {
+                return false;
+            }
+            return new $klass(array_pop($dbrecords));
+        } else {
+            // Supplied data with object ID.
+            if ($reload) {
+                // Reload all data from ID.
+                $dbrecord = $DB->get_record(static::get_table_name(), ['id' => $recordid]);
+            }
             if (!$dbrecord) {
                 return false;
             }
+            // No reload required, populate object from data provided.
             return new $klass($dbrecord);
         }
+    }
 
-        if ($dbrecord) {
-            $record = new $klass($dbrecord);
-            if ($reload) {
-                $record->reload();
-            }
-            return $record;
+    /**
+     * Get the record ID from supplied data (which may be of various types).
+     * @param stdClass|array|table_base $record
+     * @return int|null
+     */
+    public static function get_id_from_record($record): ?int {
+        if (!$record) {
+            throw new coding_exception("No record");
         }
-
-        return false;
+        if (is_object($record) && isset($record->id)) {
+            return (int)$record->id;
+        }
+        if (is_array($record) && isset($record['id'])) {
+            return (int)$record['id'];
+        }
+        if (is_object($record) && method_exists($record, 'id')) {
+            return $record->id();
+        }
+        return null;
     }
 
     /**
@@ -164,16 +204,20 @@ abstract class table_base {
      */
     public function __construct($dbrecord = false) {
 
-        // Allow the option to supply an id if this is not being generated as part of a massive list
-        // of courseworks. If the id isn't there, throw an error. Weirdly, everything comes through
-        // as a string here.
-        if (!empty($dbrecord) && is_numeric($dbrecord)) {
-            $this->id = $dbrecord;
-            $this->reload();
-        } else if (is_object($dbrecord) || is_array($dbrecord)) {
-            // Add all of the DB row fields to this object (if the object has a matching property).
-            $this->apply_data($dbrecord);
-            $this->dataloaded = true;
+        if ($dbrecord) {
+            // If we do not have a DB record here, we must be building a new object (does not yet exist in DB).
+            // That is allowed, but obviously we do not yet have any data in the DB for this object.
+            // Allow option to supply an id e.g. if this is not being generated as part of a massive list of objects.
+            if (is_numeric($dbrecord)) {
+                $this->id = (int)$dbrecord;
+                $this->reload();
+            } else if ($id = self::get_id_from_record($dbrecord)) {
+                // We have an object or array and have been provided with the ID.
+                // Add all of the DB row fields to this object (if the object has a matching property).
+                $this->apply_data($dbrecord);
+                $this->id = $id;
+                $this->dataloaded = true;
+            }
         }
     }
 
@@ -260,6 +304,10 @@ abstract class table_base {
         $data = (array)$dataobject;
         foreach (static::get_column_names() as $columnname) {
             if (isset($data[$columnname])) {
+                if ($columnname == 'id') {
+                    // This prop is read only - set once and never from here.
+                    continue;
+                }
                 $this->{$columnname} = $data[$columnname];
             }
         }
@@ -329,10 +377,10 @@ abstract class table_base {
      * @return bool
      * @throws dml_exception
      */
-    public function persisted() {
-        global $DB;
-
-        return !empty($this->id) && $DB->record_exists(static::$tablename, ['id' => $this->id]);
+    public function persisted(): bool {
+        // Previously was a check against DB here but this results in thousands of queries from grading report page via ability->can().
+        // ID should only be set from a DB record anyway so that check is now removed.
+        return !empty($this->id);
     }
 
     /**
@@ -409,7 +457,7 @@ abstract class table_base {
     public function reload($complainifnotfound = true) {
         global $DB;
 
-        if (empty($this->id)) {
+        if (!$this->persisted()) {
             return $this;
         }
 
@@ -461,7 +509,7 @@ abstract class table_base {
     public function destroy() {
         global $DB;
 
-        if (empty($this->id)) {
+        if (!$this->persisted()) {
             throw new coding_exception('Cannot destroy an object that has not yet been saved');
         }
 
@@ -502,7 +550,10 @@ abstract class table_base {
 
         // Only save the non-null fields.
         foreach (static::get_column_names() as $columnname) {
-            if (!is_null($this->$columnname)) {
+            if ($columnname == 'id' && !$this->persisted()) {
+                continue;
+            }
+            if (isset($this->$columnname) && !is_null($this->$columnname)) {
                 $savedata->$columnname = $this->$columnname;
             }
         }
@@ -620,11 +671,11 @@ abstract class table_base {
     }
 
     /**
-     * @return int|string
+     * @return int
      * @throws coding_exception
      */
-    public function id() {
-        if (empty($this->id)) {
+    public function id(): int {
+        if (!$this->persisted()) {
             throw new coding_exception('Asking for the id of an unsaved object');
         }
         return $this->id;

--- a/classes/framework/table_base.php
+++ b/classes/framework/table_base.php
@@ -109,9 +109,9 @@ abstract class table_base {
 
             $dbrecords = $DB->get_records(static::get_table_name(), $filteredparams, '', '*', 0, 2);
             if (count($dbrecords) > 1) {
-                throw new invalid_parameter_exception("Found multiple records with supplied properties " . json_encode($dbrecord) . "||" . json_encode($dbrecords));
+                throw new coding_exception("Found multiple records with supplied properties " . json_encode($filteredparams));
             }
-            if (!$dbrecords) {
+            if (empty($dbrecords)) {
                 return false;
             }
             return new $klass(array_pop($dbrecords));

--- a/classes/framework/table_base.php
+++ b/classes/framework/table_base.php
@@ -321,8 +321,14 @@ abstract class table_base {
      * @throws dml_exception
      */
     final public function save($sneakily = false) {
-
         global $DB;
+        if (static::get_table_name() !== 'coursework' && !str_starts_with(static::get_table_name(), 'coursework_')) {
+            // Some child classes e.g. user, group, modules do not use coursework_ tables but core tables.
+            // Prevent accidental data modification.
+            throw new coding_exception(
+                "Cannot modify non-coursework data, in table '" . static::get_table_name() . "', from this class"
+            );
+        }
 
         $this->pre_save_hook();
 

--- a/classes/grade_judge.php
+++ b/classes/grade_judge.php
@@ -130,14 +130,14 @@ class grade_judge {
      */
     public function get_feedback_that_is_promoted_to_gradebook($submission) {
 
-        if (!isset($submission->id)) {
+        if (!$submission->id()) {
             return new null_feedback();
         }
 
         if ($this->allocatable_needs_more_than_one_feedback($submission->get_allocatable())) {
-            $feedback = feedback::find(['submissionid' => $submission->id, 'stageidentifier' => 'final_agreed_1']);
+            $feedback = feedback::find(['submissionid' => $submission->id(), 'stageidentifier' => 'final_agreed_1']);
         } else {
-            $feedback = feedback::find(['submissionid' => $submission->id, 'stageidentifier' => 'assessor_1']);
+            $feedback = feedback::find(['submissionid' => $submission->id(), 'stageidentifier' => 'assessor_1']);
         }
 
         return $feedback ? $feedback : new null_feedback();
@@ -148,7 +148,7 @@ class grade_judge {
      * @return bool
      */
     public function has_feedback_that_is_promoted_to_gradebook($submission) {
-        return $this->get_feedback_that_is_promoted_to_gradebook($submission)->id != 0;
+        return $this->get_feedback_that_is_promoted_to_gradebook($submission)->id() != 0;
     }
 
     /**
@@ -165,7 +165,7 @@ class grade_judge {
      */
     public function is_feedback_that_is_promoted_to_gradebook(feedback $feedback) {
         $gradebookfeedback = $this->get_feedback_that_is_promoted_to_gradebook($feedback->get_submission());
-        return $gradebookfeedback && $gradebookfeedback->id == $feedback->id;
+        return $gradebookfeedback && $gradebookfeedback->id() == $feedback->id;
     }
 
     /**

--- a/classes/models/allocation.php
+++ b/classes/models/allocation.php
@@ -44,11 +44,6 @@ class allocation extends table_base {
     /**
      * @var int
      */
-    public $id;
-
-    /**
-     * @var int
-     */
     public $courseworkid;
 
     /**

--- a/classes/models/course_module.php
+++ b/classes/models/course_module.php
@@ -36,11 +36,6 @@ class course_module extends table_base {
     protected static $tablename = 'course_modules';
 
     /**
-     * @var int
-     */
-    public $id;
-
-    /**
      * cache array
      *
      * @var

--- a/classes/models/coursework.php
+++ b/classes/models/coursework.php
@@ -105,11 +105,6 @@ class coursework extends table_base {
     /**
      * @var int
      */
-    public $id;
-
-    /**
-     * @var int
-     */
     public $formid;
 
     /**

--- a/classes/models/feedback.php
+++ b/classes/models/feedback.php
@@ -51,11 +51,6 @@ class feedback extends table_base {
     /**
      * @var int
      */
-    public $id;
-
-    /**
-     * @var int
-     */
     public $submissionid;
 
     /**

--- a/classes/models/group.php
+++ b/classes/models/group.php
@@ -63,7 +63,7 @@ class group extends table_base implements allocatable, moderatable {
     /**
      * @return int
      */
-    public function id() {
+    public function id(): int {
         return $this->id;
     }
 

--- a/classes/models/moderation.php
+++ b/classes/models/moderation.php
@@ -37,11 +37,6 @@ class moderation extends table_base {
     /**
      * @var int
      */
-    public $id;
-
-    /**
-     * @var int
-     */
     public $feedbackid;
 
     /**

--- a/classes/models/moderation_set_rule.php
+++ b/classes/models/moderation_set_rule.php
@@ -51,11 +51,6 @@ abstract class moderation_set_rule extends table_base implements renderable {
     /**
      * @var int
      */
-    public $id;
-
-    /**
-     * @var int
-     */
     public $courseworkid;
 
     /**

--- a/classes/models/module.php
+++ b/classes/models/module.php
@@ -35,10 +35,6 @@ class module extends table_base {
      */
     protected static $tablename = 'modules';
 
-    /**
-     * @var int
-     */
-    public $id;
 
     /**
      * cache array

--- a/classes/models/null_feedback.php
+++ b/classes/models/null_feedback.php
@@ -34,12 +34,16 @@ class null_feedback {
     /**
      * @var int
      */
-    public $id = 0;
+    protected $id = 0;
 
     /**
      * @return string
      */
     public function get_grade() {
         return '';
+    }
+
+    public function id(): int {
+        return $this->id;
     }
 }

--- a/classes/models/null_user.php
+++ b/classes/models/null_user.php
@@ -39,7 +39,7 @@ class null_user implements allocatable {
     /**
      * @return int
      */
-    public function id() {
+    public function id(): int {
         return 0;
     }
 

--- a/classes/models/sample_set_rule.php
+++ b/classes/models/sample_set_rule.php
@@ -50,11 +50,6 @@ abstract class sample_set_rule extends table_base implements renderable {
     /**
      * @var int
      */
-    public $id;
-
-    /**
-     * @var int
-     */
     public $courseworkid;
 
     /**

--- a/lib.php
+++ b/lib.php
@@ -641,7 +641,7 @@ function coursework_update_events($coursework, $eventtype) {
 
     // Update/create event for coursework deadline [due].
     if ($eventtype == coursework::COURSEWORK_EVENT_TYPE_DUE) {
-        $data = calendar::coursework_event($coursework, $eventtype, $coursework->deadline);
+        $data = calendar::coursework_event(coursework::find($coursework), $eventtype, $coursework->deadline);
         if ($event) {
             $event->update($data); // Update if event exists.
         } else {

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -48,7 +48,7 @@ class mod_coursework_generator extends testing_module_generator {
      *                               - all else is optional and defaults will be supplied
      * @param array|null $options extra stuff for the coursemodule. idnumber, section, visible, etc.
      * @throws coding_exception
-     * @return \mod_coursework\models\coursework activity record with extra cmid field
+     * @return coursework
      */
     public function create_instance($record = null, ?array $options = null) {
 
@@ -104,7 +104,8 @@ class mod_coursework_generator extends testing_module_generator {
             $record->moderatorallocationstrategy = 'none';
         }
 
-        return parent::create_instance($record, $options);
+        $instance = parent::create_instance($record, $options);
+        return coursework::find($instance);
     }
 
     /**

--- a/tests/phpunit/grade_judge_test.php
+++ b/tests/phpunit/grade_judge_test.php
@@ -45,7 +45,7 @@ final class grade_judge_test extends \advanced_testcase {
         $assessor = $this->create_a_teacher();
         $feedback = $this->create_an_assessor_feedback_for_the_submission($assessor);
 
-        $this->assertEquals($feedback->id, $gradejudge->get_feedback_that_is_promoted_to_gradebook($submission)->id);
+        $this->assertEquals($feedback->id(), $gradejudge->get_feedback_that_is_promoted_to_gradebook($submission)->id());
     }
 
     public function test_sampling_disabled_one_marker(): void {

--- a/tests/phpunit/models/deadline_extension_test.php
+++ b/tests/phpunit/models/deadline_extension_test.php
@@ -50,6 +50,7 @@ final class deadline_extension_test extends \advanced_testcase {
                         'extended_deadline' => time()];
         $newthing = deadline_extension::create($params);
         $this->assertInstanceOf('mod_coursework\models\deadline_extension', $newthing);
+        $this->assertTrue($newthing->persisted());
     }
 
     public function test_user_extension_allows_submission_when_active(): void {

--- a/tests/phpunit/models/group_test.php
+++ b/tests/phpunit/models/group_test.php
@@ -44,6 +44,8 @@ final class group_test extends \advanced_testcase {
         $group = $generator->create_group($group);
 
         $this->assertNotEmpty($group->name);
-        $this->assertEquals($group->name, group::find($group->id)->name);
+        $courseworkgroup = group::find($group->id);
+        $this->assertEquals($group->name, $courseworkgroup->name);
+        $this->assertTrue($courseworkgroup->persisted());
     }
 }

--- a/tests/phpunit/models/submission_test.php
+++ b/tests/phpunit/models/submission_test.php
@@ -91,11 +91,15 @@ final class submission_test extends \advanced_testcase {
     public function test_save_courseworkid(): void {
         $submission = new submission();
         $submission->courseworkid = $this->coursework->id;
+
+        $this->assertFalse($submission->persisted());
         $submission->save();
+        $this->assertTrue($submission->persisted());
 
         $retrieved = submission::find($submission->id);
+        $this->assertequals($submission->id(), $retrieved->id());
 
-        $this->assertNotEmpty($retrieved->courseworkid);
+        $this->assertEquals($this->coursework->id, $retrieved->courseworkid);
     }
 
     public function test_group_decorator_is_not_added(): void {

--- a/tests/phpunit/models/user_test.php
+++ b/tests/phpunit/models/user_test.php
@@ -101,7 +101,14 @@ final class user_test extends \advanced_testcase {
         $this->assertTrue($this->get_student()->has_all_initial_feedbacks($this->get_coursework()));
     }
 
-    public function test_persisted() {
+    /**
+     * Test that user::find() and user->persisted() working as expected.
+     * @covers \mod_coursework\models\user::find()
+     * @covers \mod_coursework\framework\table_base::find()
+     * @covers \mod_coursework\framework\table_base::persisted()
+     * @throws \core\exception\invalid_parameter_exception
+     */
+    public function test_persisted(): void {
         $generator = testing_util::get_data_generator();
 
         $user = new stdClass();

--- a/tests/phpunit/models/user_test.php
+++ b/tests/phpunit/models/user_test.php
@@ -109,6 +109,7 @@ final class user_test extends \advanced_testcase {
      * @throws \core\exception\invalid_parameter_exception
      */
     public function test_persisted(): void {
+        global $DB;
         $generator = testing_util::get_data_generator();
 
         $user = new stdClass();
@@ -124,15 +125,22 @@ final class user_test extends \advanced_testcase {
         $this->assertEquals($dbstudent->id, $courseworkuser->id());
 
         // Find the user coursework object without providing their ID, using an object.
-        $courseworkuser = user::find($user);
-        $this->assertNotFalse($courseworkuser);
-        $this->assertTrue($courseworkuser->persisted());
-        $this->assertEquals($dbstudent->id, $courseworkuser->id());
-
-        // Find the user coursework object providing their ID.
-        $courseworkuser2 = user::find($dbstudent, true);
+        $courseworkuser2 = user::find($user);
         $this->assertNotFalse($courseworkuser2);
         $this->assertTrue($courseworkuser2->persisted());
         $this->assertEquals($dbstudent->id, $courseworkuser2->id());
+
+        // Find the user coursework object providing their ID.
+        $courseworkuser3 = user::find($dbstudent);
+        $this->assertNotFalse($courseworkuser3);
+        $this->assertTrue($courseworkuser3->persisted());
+        $this->assertEquals($dbstudent->id, $courseworkuser3->id());
+
+        // Find the user coursework object providing a fresh DB record ID, preventing reload.
+        $dbrecord = $DB->get_record('user', ['id' => $dbstudent->id], '*', MUST_EXIST);
+        $courseworkuser4 = user::find($dbrecord, false);
+        $this->assertNotFalse($courseworkuser4);
+        $this->assertTrue($courseworkuser4->persisted());
+        $this->assertEquals($dbrecord->id, $courseworkuser4->id());
     }
 }

--- a/tests/phpunit/models/user_test.php
+++ b/tests/phpunit/models/user_test.php
@@ -16,6 +16,10 @@
 
 namespace mod_coursework;
 
+use mod_coursework\models\user;
+use stdClass;
+use testing_util;
+
 /**
  * @package    mod_coursework
  * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
@@ -95,5 +99,33 @@ final class user_test extends \advanced_testcase {
         $teacher = $this->create_a_teacher();
         $this->create_an_assessor_feedback_for_the_submission($teacher);
         $this->assertTrue($this->get_student()->has_all_initial_feedbacks($this->get_coursework()));
+    }
+
+    public function test_persisted() {
+        $generator = testing_util::get_data_generator();
+
+        $user = new stdClass();
+        $user->firstname = 'Rare name';
+        $user->Lastname = 'Smith';
+        $dbstudent = $generator->create_user($user);
+        $this->assertNotFalse($dbstudent);
+
+        // Find the user coursework object without providing their ID, using an array.
+        $courseworkuser = user::find((array)$user);
+        $this->assertNotFalse($courseworkuser);
+        $this->assertTrue($courseworkuser->persisted());
+        $this->assertEquals($dbstudent->id, $courseworkuser->id());
+
+        // Find the user coursework object without providing their ID, using an object.
+        $courseworkuser = user::find($user);
+        $this->assertNotFalse($courseworkuser);
+        $this->assertTrue($courseworkuser->persisted());
+        $this->assertEquals($dbstudent->id, $courseworkuser->id());
+
+        // Find the user coursework object providing their ID.
+        $courseworkuser2 = user::find($dbstudent, true);
+        $this->assertNotFalse($courseworkuser2);
+        $this->assertTrue($courseworkuser2->persisted());
+        $this->assertEquals($dbstudent->id, $courseworkuser2->id());
     }
 }

--- a/tests/phpunit/renderer_test.php
+++ b/tests/phpunit/renderer_test.php
@@ -60,19 +60,19 @@ final class renderer_test extends \advanced_testcase {
 
         $coursework = $this->create_a_coursework($courseworkparams);
 
-        // Create student and cast to stdClass.
-        $student = (object) (array) $this->create_a_student();
+        $student = $this->create_a_student();
 
         if ($extensiondate !== 0) {
-            $extension = deadline_extension::create([
+            $extension = deadline_extension::build([
                 'allocatableid' => $student->id,
                 'allocatabletype' => 'user',
                 'courseworkid' => $coursework->id,
                 'extended_deadline' => $extensiondate,
             ]);
+            $extension->save();
         }
 
-        $this->setUser($student);
+        $this->setUser((object)['id' => $student->id]);
         $objectrenderer = $PAGE->get_renderer('mod_coursework', 'object');
         $html = $objectrenderer->render(new \mod_coursework_coursework($coursework));
 
@@ -156,9 +156,9 @@ final class renderer_test extends \advanced_testcase {
         $coursework = $this->create_a_coursework($courseworkparams);
 
         // Create teacher and cast to stdClass.
-        $teacher = (object) (array) $this->create_a_teacher();
+        $teacher = $this->create_a_teacher();
 
-        $this->setUser($teacher);
+        $this->setUser((object)['id' => $teacher->id]);
         $objectrenderer = $PAGE->get_renderer('mod_coursework', 'object');
         $html = $objectrenderer->render(new \mod_coursework_coursework($coursework));
 

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_coursework';
 
-$plugin->version = 2025120401;  // If version == 0 then module will not be installed.
+$plugin->version = 2025121500;  // If version == 0 then module will not be installed.
 $plugin->requires = 2024100700;  // Requires this Moodle version.
 
 $plugin->cron = 300;        // Period for cron to check this module (secs).


### PR DESCRIPTION
- remove wasteful check against database by table_base::persisted() (causing unnecessary DB activity on grading page)
- make table_base::id protected and readonly given removal of the above check
- consequential changes elsewhere
- add to tests