### PR TITLE
CTP-5559: Fix permissions check in ability class

### DIFF
--- a/classes/ability.php
+++ b/classes/ability.php
@@ -903,7 +903,7 @@ class ability extends framework\ability {
                 if ($stage->uses_allocation() && $feedback->get_coursework()->allocation_enabled()) {
                     $allocatedteacher = $stage->allocated_teacher_for($allocatable);
                     if ($allocatedteacher) {
-                        if ($allocatedteacher->id == $this->user->id) {
+                        if ($allocatedteacher->id == $this->userid) {
                             return true;
                         }
                     }
@@ -1164,7 +1164,7 @@ class ability extends framework\ability {
             'show',
             'mod_coursework\models\allocation',
             function (allocation $allocation) {
-                return $this->user->id == $allocation->assessorid;
+                return $this->userid == $allocation->assessorid;
             }
         );
     }

--- a/tests/behat/allocation_visibility_of_allocated_teachers.feature
+++ b/tests/behat/allocation_visibility_of_allocated_teachers.feature
@@ -9,6 +9,8 @@ Feature: Visibility of allocated teachers
     Given there is a course
     And there is a coursework
     And there is a student
+    And the student has a submission
+    And the submission is finalised
 
   Scenario: I should see the name of the allocated teacher in the assessor feedback cell
     Given there is a teacher
@@ -17,4 +19,9 @@ Feature: Visibility of allocated teachers
     And the student is manually allocated to the teacher
     When I log in as a manager
     And I visit the coursework page
-    Then I should see the name of the teacher in the assessor feedback cell
+    Then I should see "teacher teacher2" in the "student1" "table_row"
+    And I log out
+
+    Given I am logged in as a teacher
+    And I visit the coursework page
+    Then I should see "Add mark" in the "student1" "table_row"


### PR DESCRIPTION
Pre-existing bug that was exposed by CTP-5490
A couple of ability checks failed as the get_user function which populated the user property was no longer being called.
Also reinstated and extended the relevant behat test.