### PR TITLE
CTP-5490-performance-sample-count

### DIFF
--- a/backup/moodle2/restore_coursework_stepslib.php
+++ b/backup/moodle2/restore_coursework_stepslib.php
@@ -21,6 +21,7 @@
  */
 
 use mod_coursework\models\submission;
+use mod_coursework\models\assessment_set_membership;
 
 class restore_coursework_activity_structure_step extends restore_activity_structure_step {
     /**
@@ -287,7 +288,7 @@ class restore_coursework_activity_structure_step extends restore_activity_struct
                                   'stageidentifier' => '',
                                   'selectiontype' => ''], $data);
 
-        $DB->insert_record('coursework_sample_set_mbrs', $data);
+        assessment_set_membership::create($data);
     }
 
     protected function process_coursework_extension($data) {

--- a/classes/models/assessment_set_membership.php
+++ b/classes/models/assessment_set_membership.php
@@ -134,7 +134,7 @@ class assessment_set_membership extends table_base implements moderatable {
     public static function membership_count(int $courseworkid, string $allocatabletype, int $allocatableid): int {
         global $DB;
         // This is called over and over during rendering of the grading page, so cache the result.
-        $cachekey = $courseworkid . "_" . $allocatabletype . "_" . $allocatableid;
+        $cachekey = self::membership_count_cache_key($courseworkid, $allocatabletype, $allocatableid);
 
         $cache = cache::make('mod_coursework', self::CACHE_AREA_MEMBER_COUNT);
         $cachedvalue = $cache->get($cachekey);
@@ -178,6 +178,16 @@ class assessment_set_membership extends table_base implements moderatable {
         }
     }
 
+    /**
+     * Get the cache key used for membership count cache.
+     * @param int $courseworkid
+     * @param string $allocatabletype
+     * @param int $allocatableid
+     * @return string
+     */
+    private static function membership_count_cache_key(int $courseworkid, string $allocatabletype, int $allocatableid): string {
+        return $courseworkid . "_" . $allocatabletype . "_" . $allocatableid;
+    }
 
     /**
      * Makes a new instance and saves it.
@@ -188,7 +198,7 @@ class assessment_set_membership extends table_base implements moderatable {
     public static function create($params) {
         $cache = cache::make('mod_coursework', self::CACHE_AREA_MEMBER_COUNT);
         $params = (array)$params;
-        $cache->delete($params['courseworkid'] . "_" . $params['allocatabletype'] . "_" . $params['allocatableid']);
+        $cache->delete(self::membership_count_cache_key($params['courseworkid'], $params['allocatabletype'], $params['allocatableid']));
         return parent::create($params);
     }
 

--- a/classes/stages/base.php
+++ b/classes/stages/base.php
@@ -566,19 +566,21 @@ abstract class base {
     }
 
     /**
+     * Remove allocatable from sampling.
      * @param allocatable $allocatable
-     * @throws \dml_exception
+     * @throws \dml_exception|coding_exception
      */
     public function remove_allocatable_from_sampling($allocatable) {
-        global $DB;
-
         $params = [
             'courseworkid' => $this->coursework->id,
             'allocatableid' => $allocatable->id(),
             'allocatabletype' => $allocatable->type(),
             'stageidentifier' => $this->stageidentifier,
         ];
-        $DB->delete_records('coursework_sample_set_mbrs', $params);
+        $membership = assessment_set_membership::find($params, false);
+        if ($membership) {
+            $membership->destroy();
+        }
     }
 
     /**

--- a/classes/traits/allocatable_functions.php
+++ b/classes/traits/allocatable_functions.php
@@ -22,6 +22,7 @@
 
 namespace mod_coursework\traits;
 use core\exception\coding_exception;
+use mod_coursework\models\assessment_set_membership;
 use mod_coursework\models\coursework;
 use mod_coursework\models\feedback;
 use mod_coursework\models\submission;
@@ -135,20 +136,11 @@ trait allocatable_functions {
 
         // when sampling is enabled, calculate how many stages are in sample
         if ($coursework->sampling_enabled()) {
-            $sql = "SELECT COUNT(*)
-                  FROM {coursework_sample_set_mbrs}
-                  WHERE courseworkid = :courseworkid
-                  AND allocatableid = :allocatableid
-                  AND allocatabletype = :allocatabletype";
-
-            $markers = $DB->count_records_sql(
-                $sql,
-                ['courseworkid' => $coursework->id(),
-                    'allocatableid' => $this->id(),
-                'allocatabletype' => $this->type()]
-            );
-
-            $expectedmarkers = $markers + 1; // there is always a marker for stage 1
+            $expectedmarkers = assessment_set_membership::membership_count(
+                $coursework->id(),
+                $this->id(),
+                $this->type()
+            ) + 1;  // Add one as there is always a marker for stage 1.
         }
 
         return $feedbacks == $expectedmarkers;

--- a/db/caches.php
+++ b/db/caches.php
@@ -16,6 +16,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+use mod_coursework\models\assessment_set_membership;
+
 /**
  * @package    mod_coursework
  * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
@@ -25,5 +27,10 @@ defined('MOODLE_INTERNAL') || die();
 $definitions = [
     'courseworkdata' => [
         'mode' => cache_store::MODE_APPLICATION,
+    ],
+    assessment_set_membership::CACHE_AREA_MEMBER_COUNT => [
+        'mode' => cache_store::MODE_APPLICATION,
+        'simplekeys' => true,
+        'simpledata' => true,
     ],
 ];

--- a/lang/en/coursework.php
+++ b/lang/en/coursework.php
@@ -95,6 +95,7 @@ $string['blindmarking'] = 'Blind marking';
 $string['blindmarking_desc'] = 'Blind marking - You will not see students\' names';
 $string['blindmarking_help'] = 'Blind marking prevents people without the mod/coursework:viewanonymous capability from seeing the real names of the students. It also prevents people who are allowed to add agreed marks from seeing the initial marks added by other people until they have all been added. This will be fixed permanently once set and cannot be ' . 'changed later.';
 $string['cachedef_courseworkdata'] = 'Cache to store coursework data';
+$string['cachedef_samplesetmembershipcount'] = 'Marking allocation sample set membership count';
 $string['candidate_number_provider'] = 'Candidate number provider';
 $string['candidate_number_provider_desc'] = 'Select a candidate number provider to use for file renaming. Only available when providers are installed.';
 $string['cannot_change_candidate'] = 'Cannot change candidate number setting after students have submitted files.';

--- a/tests/phpunit/allocation/assessment_set_membership_test.php
+++ b/tests/phpunit/allocation/assessment_set_membership_test.php
@@ -1,0 +1,122 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace mod_coursework;
+
+/**
+ * @package    mod_coursework
+ * @copyright  2025 UCL
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+/**
+ * Unit tests for the assessment_set_membership class.
+ * @group mod_coursework
+ */
+
+use core_cache\cache;
+use mod_coursework\models\assessment_set_membership;
+
+final class assessment_set_membership_test extends \advanced_testcase {
+    use test_helpers\factory_mixin;
+
+    public function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+    }
+
+    /**
+     * Two students but only one is double marked and should have agreed grade, extension not enabled
+     */
+    public function test_create_and_count(): void {
+        $this->setAdminUser();
+        $generator = $this->getDataGenerator()->get_plugin_generator('mod_coursework');
+
+        $params = [
+            'grade' => 100,
+            'numberofmarkers' => 2,
+            'samplingenabled' => 1,
+            'deadline' => time() + 86400,
+        ];
+        $coursework = $this->create_a_coursework($params);
+        $student1 = $this->create_a_student();
+        $submission1 = new \stdClass();
+        $submission1->userid = $student1->id;
+        $submission1->allocatableid = $student1->id;
+        $submission1 = $generator->create_submission($submission1, $coursework);
+
+        $this->assertEquals(
+            0,
+            assessment_set_membership::membership_count(
+                $coursework->id,
+                $submission1->allocatabletype,
+                $submission1->allocatableid,
+            )
+        );
+        $setmembersdata = new \stdClass();
+        $setmembersdata->courseworkid = $coursework->id;
+        $setmembersdata->allocatableid = $submission1->allocatableid;
+        $setmembersdata->allocatabletype = 'user';
+        $setmembersdata->stageidentifier = 'assessor_1';
+        $membership = assessment_set_membership::create($setmembersdata);
+        $this->assertEquals(
+            1,
+            assessment_set_membership::membership_count(
+                $coursework->id,
+                $submission1->allocatabletype,
+                $submission1->allocatableid,
+            )
+        );
+
+        // Test accessing cached count directly.
+        $cache = cache::make('mod_coursework', assessment_set_membership::CACHE_AREA_MEMBER_COUNT);
+        $cachekey = "{$coursework->id}_{$submission1->allocatabletype}_{$submission1->allocatableid}";
+        $this->assertEquals(1, $cache->get($cachekey));
+
+        $membership->membership_count_clear_cache_for_coursework();
+        $this->assertTrue($cache->get($cachekey) === false);
+        // Count of 1 is re-populated after cache just cleared.
+        $this->assertEquals(
+            1,
+            assessment_set_membership::membership_count(
+                $coursework->id,
+                $submission1->allocatabletype,
+                $submission1->allocatableid,
+            )
+        );
+        $this->assertEquals(1, $cache->get($cachekey));
+
+        $this->assertEquals(
+            $membership,
+            assessment_set_membership::find($membership->id)
+        );
+
+        $this->assertEquals(
+            $membership,
+            assessment_set_membership::find($setmembersdata)
+        );
+
+        $membership->destroy();
+        $this->assertEquals(
+            0,
+            assessment_set_membership::membership_count(
+                $coursework->id,
+                $submission1->allocatabletype,
+                $submission1->allocatableid,
+            )
+        );
+    }
+}

--- a/tests/phpunit/export/csv_test.php
+++ b/tests/phpunit/export/csv_test.php
@@ -25,6 +25,7 @@ namespace mod_coursework;
  */
 
 use mod_coursework\models\deadline_extension;
+use mod_coursework\models\assessment_set_membership;
 
 /**
  * @property mixed feedback_data
@@ -346,8 +347,7 @@ final class csv_test extends \advanced_testcase {
         $setmembersdata->allocatableid = $submission2->allocatableid;
         $setmembersdata->allocatabletype = 'user';
         $setmembersdata->stageidentifier = 'assessor_2';
-
-        $DB->insert_record('coursework_sample_set_mbrs', $setmembersdata);
+        assessment_set_membership::create($setmembersdata);
 
         // Assessor one feedback for student 1.
         $feedbackdata1 = new \stdClass();

--- a/tests/phpunit/models/moderation_set_membership_test.php
+++ b/tests/phpunit/models/moderation_set_membership_test.php
@@ -16,6 +16,8 @@
 
 namespace mod_coursework;
 
+use mod_coursework\models\assessment_set_membership;
+
 /**
  * @package    mod_coursework
  * @copyright  2017 University of London Computer Centre {@link https://www.cosector.com}
@@ -33,14 +35,12 @@ final class moderation_set_membership_test extends \advanced_testcase {
     }
 
     public function test_find(): void {
-        global $DB;
-
         $record = new \stdClass();
         $record->allocatableid = 22;
         $record->allocatabletype = 'user';
         $record->courseworkid = 44;
-        $record->id = $DB->insert_record('coursework_sample_set_mbrs', $record);
+        $membership = assessment_set_membership::create($record);
 
-        $this->assertEquals(22, \mod_coursework\models\assessment_set_membership::find($record->id)->allocatableid);
+        $this->assertEquals(22, \mod_coursework\models\assessment_set_membership::find($membership->id())->allocatableid);
     }
 }

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_coursework';
 
-$plugin->version = 2025121500;  // If version == 0 then module will not be installed.
+$plugin->version = 2025121602;  // If version == 0 then module will not be installed.
 $plugin->requires = 2024100700;  // Requires this Moodle version.
 
 $plugin->cron = 300;        // Period for cron to check this module (secs).


### PR DESCRIPTION
- when marker allocation and sampling is enabled for a coursework, mdl_coursework_sample_set_mbrs is repeatedly queried when grading page is loaded to establish for each user how many feedbacks we expect
- this introduces assessment_set_membership::membership_count() to get that count but using a cache
- other changes to the code to update cache when appropriate (i.e. when samples change)