### PR TITLE
Ctp 5490 performance ability

### DIFF
--- a/classes/ability.php
+++ b/classes/ability.php
@@ -1008,12 +1008,14 @@ class ability extends framework\ability {
             'edit',
             'mod_coursework\models\feedback',
             function (feedback $feedback) {
-                $isinitialgrade = $feedback->is_initial_assessor_feedback();
-                $hascapability = has_capability('mod/coursework:editinitialgrade', $feedback->get_context());
-                $iscreator = $feedback->assessorid == $this->userid;
-                $isallocated = $feedback->is_assessor_allocated();
-
-                return $isinitialgrade && $hascapability && ($iscreator || $isallocated);
+                if (!has_capability('mod/coursework:editinitialgrade', $feedback->get_context())) {
+                    return false;
+                }
+                if (!$feedback->is_initial_assessor_feedback()) {
+                    return false;
+                }
+                return $feedback->assessorid == $this->userid
+                    || $feedback->is_assessor_allocated(); // Line may involve a database query so done last.
             }
         );
     }

--- a/classes/export/csv/cells/agreedgrade_cell.php
+++ b/classes/export/csv/cells/agreedgrade_cell.php
@@ -162,31 +162,23 @@ class agreedgrade_cell extends cell_base {
             }
 
             // Has this submission been graded if yes then check if the current user graded it (only if allocation is not enabled).
-            $feedbackparams = [
-                'submissionid' => $submission->id,
-                'stageidentifier' => $stageident,
-            ];
-
-            $feedback = feedback::find($feedbackparams);
-
-            $ability = new ability($USER->id, $this->coursework);
+            $feedback = feedback::find(['submissionid' => $submission->id, 'stageidentifier' => $stageident]);
 
             // Does a feedback exist for this stage
             if (empty($feedback)) {
-                $feedbackparams = [
-                    'submissionid' => $submissionid,
-                    'assessorid' => $USER->id,
-                    'stageidentifier' => $stageident,
-                ];
-                $newfeedback = feedback::build($feedbackparams);
-
                 // This is a new feedback check it against the new ability checks
-                if (!has_capability('mod/coursework:administergrades', $PAGE->context) && !has_capability('mod/coursework:addallocatedagreedgrade', $PAGE->context) && !$ability->can('new', $newfeedback)) {
+                if (
+                    !has_capability('mod/coursework:administergrades', $PAGE->context)
+                    && !has_capability('mod/coursework:addallocatedagreedgrade', $PAGE->context)
+                    && !feedback::can_add_new($this->coursework, $submission, $stageident)
+                ) {
                     return get_string('nopermissiontomarksubmission', 'coursework');
                 }
             } else {
-                // This is a new feedback check it against the edit ability checks
-                if (!has_capability('mod/coursework:administergrades', $PAGE->context) && !$ability->can('edit', $feedback)) {
+                if (
+                    !has_capability('mod/coursework:administergrades', $PAGE->context)
+                    && !$feedback->can_edit($this->coursework, $submission)
+                ) {
                     return get_string('nopermissiontoeditmark', 'coursework');
                 }
             }

--- a/classes/export/csv/cells/feedbackcomments_cell.php
+++ b/classes/export/csv/cells/feedbackcomments_cell.php
@@ -82,8 +82,6 @@ class feedbackcomments_cell extends cell_base {
                 return get_string('nopermissiontomarksubmission', 'coursework');
             }
 
-            $ability = new ability($USER->id, $this->coursework);
-
             $feedbackparams = [
                 'submissionid' => $submission->id,
                 'stageidentifier' => $stageidentifier,
@@ -92,20 +90,13 @@ class feedbackcomments_cell extends cell_base {
 
             // Does a feedback exist for this stage
             if (empty($feedback)) {
-                $feedbackparams = [
-                    'submissionid' => $submissionid,
-                    'assessorid' => $USER->id,
-                    'stageidentifier' => $stageidentifier,
-                ];
-                $newfeedback = feedback::build($feedbackparams);
-
                 // This is a new feedback check it against the new ability checks
-                if (!$ability->can('new', $newfeedback)) {
+                if (!feedback::can_add_new($this->coursework, $submission, $stageidentifier)) {
                     return get_string('nopermissiontomarksubmission', 'coursework');
                 }
             } else {
-                // This is a new feedback check it against the edit ability checks
-                if (!$ability->can('edit', $feedback)) {
+                // This is a new feedback check it against the edit ability checks.
+                if (!$feedback->can_edit($this->coursework, $submission)) {
                     return get_string('nopermissiontoeditmark', 'coursework');
                 }
             }

--- a/classes/export/csv/cells/singlegrade_cell.php
+++ b/classes/export/csv/cells/singlegrade_cell.php
@@ -168,24 +168,15 @@ class singlegrade_cell extends cell_base {
                 }
             }
 
-            $ability = new ability($USER->id, $this->coursework);
-
             // Does a feedback exist for this stage
             if (empty($feedback)) {
-                $feedbackparams = [
-                    'submissionid' => $submissionid,
-                    'assessorid' => $USER->id,
-                    'stageidentifier' => $stageidentifier,
-                ];
-                $newfeedback = feedback::build($feedbackparams);
-
                 // This is a new feedback check it against the new ability checks
-                if (!$ability->can('new', $newfeedback)) {
+                if (!feedback::can_add_new($this->coursework, $submission, $stageidentifier)) {
                     return get_string('nopermissiontomarksubmission', 'coursework');
                 }
             } else {
                 // This is a new feedback check it against the edit ability checks
-                if (!$ability->can('edit', $feedback)) {
+                if (!$feedback->can_edit($this->coursework, $submission)) {
                     return get_string('nopermissiontoeditmark', 'coursework');
                 }
             }

--- a/classes/models/allocation.php
+++ b/classes/models/allocation.php
@@ -220,13 +220,12 @@ class allocation extends table_base {
         ?int $assessorid = null
     ): bool {
         global $USER;
-        return (bool)self::get_object(
+        return (bool)self::get_cached_object(
             $courseworkid,
-            'allocatableid-allocatabletype-assessorid',
             [
-                $allocatableid,
-                $allocatabletype,
-                $assessorid ?? $USER->id,
+                'allocatableid' => $allocatableid,
+                'allocatabletype' => $allocatabletype,
+                'assessorid' => $assessorid ?? $USER->id,
             ]
         );
     }

--- a/classes/models/feedback.php
+++ b/classes/models/feedback.php
@@ -24,9 +24,11 @@ namespace mod_coursework\models;
 
 use AllowDynamicProperties;
 use cache;
-use coding_exception;
+use core\exception\coding_exception;
 use context;
+use core\exception\invalid_parameter_exception;
 use dml_exception;
+use mod_coursework\ability;
 use mod_coursework\allocation\allocatable;
 use mod_coursework\feedback_files;
 use mod_coursework\framework\table_base;
@@ -125,9 +127,10 @@ class feedback extends table_base {
     public $student;
 
     /**
+     * The submission object that this feedback relates to.
      * @var submission
      */
-    public $submission;
+    protected submission $submission;
 
     /**
      * @var int 1 = it is a final grade, 0 is default in the DB. Used only for multiple marked things.
@@ -459,23 +462,35 @@ class feedback extends table_base {
     /**
      * Memoized getter
      *
-     * @return bool|submission
-     * @throws \core\exception\coding_exception
-     * @throws dml_exception
+     * @return submission
+     * @throws coding_exception|dml_exception
      */
-    public function get_submission() {
+    public function get_submission(): submission {
 
-        if (!isset($this->submission) && !empty($this->submissionid)) {
-            global $DB;
-            $courseworkid = $this->courseworkid
-                ?? $DB->get_field(submission::$tablename, 'courseworkid', ['id' => $this->submissionid]);
-            if (!$courseworkid) {
-                return false;
+        if (!isset($this->submission)) {
+            if (!$this->submissionid) {
+                throw new coding_exception("Cannot get submission without ID");
             }
-            if (!isset(submission::$pool[$courseworkid])) {
-                submission::fill_pool_coursework($courseworkid);
+            if ($this->courseworkid) {
+                // We have coursework ID so try to get it from pool.
+                if (!isset(submission::$pool[$this->courseworkid])) {
+                    submission::fill_pool_coursework($this->courseworkid);
+                }
+                $submission = submission::$pool[$this->courseworkid]['id'][$this->submissionid];
+                if ($submission) {
+                    $this->set_submission($submission);
+                }
             }
-            $this->submission = submission::$pool[$courseworkid]['id'][$this->submissionid] ?? false;
+            if (!isset($this->submission)) {
+                // We still do not have submission so try to get it from DB using ID.
+                $submission = submission::find($this->submissionid) ?: null;
+                if ($submission) {
+                    $this->set_submission($submission);
+                }
+            }
+        }
+        if (!isset($this->submission)) {
+            throw new coding_exception("Could not find submission for feedback ID $this->id submission ID $this->submissionid");
         }
 
         return $this->submission;
@@ -666,7 +681,7 @@ class feedback extends table_base {
      *
      */
     protected function post_save_hook() {
-        $submission = $this->get_submission();
+        $submission = $this->submissionid ? $this->get_submission() : null;
         if ($submission && $submission->courseworkid ?? false) {
             self::remove_cache($submission->courseworkid);
         }
@@ -689,5 +704,83 @@ class feedback extends table_base {
     public function is_auto_grade(): bool {
         // Value of $this->lasteditedbyuser will be a user ID if the feedback was not auto generated.
         return $this->is_agreed_grade() && !$this->lasteditedbyuser;
+    }
+
+    /**
+     * Can the current user add a new feedback for a specific submission and stage?.
+     * Checks with ability class.
+     * For DB efficiency, requires submission and coursework objects to be passed in here, both usually already held by caller.
+     * Otherwise, on the grading page, there are repeated queries from ability class to get submission from ID.
+     * @param submission $submission
+     * @param string $stageidentifier
+     * @return bool
+     */
+    public static function can_add_new(coursework $coursework, submission $submission, string $stageidentifier): bool {
+        global $USER;
+        $feedback = self::build(
+            ['submissionid' => $submission->id, 'assessorid' => $USER->id, 'stageidentifier' => $stageidentifier]
+        );
+
+        // Add the submission object and coursework ID to the feedback object.
+        // (These are not fields in the coursework_feedbacks table so self::build() will not add them).
+        $feedback->set_submission($submission);
+        $feedback->courseworkid = $coursework->id;
+
+        $ability = new ability($USER->id, $coursework);
+        return $ability->can('new', $feedback);
+    }
+
+    /**
+     * Can the current user see a specific feedback?
+     * For DB efficiency, requires submission and coursework objects to be passed in here, both usually already held by caller.
+     * Otherwise, on the grading page, there are repeated queries to get submission from ID.
+     * @param submission $submission
+     * @return bool
+     */
+    public function can_show(coursework $coursework, submission $submission): bool {
+        return $this->can($coursework, $submission, 'show');
+    }
+
+    /**
+     * Can the current user see a specific feedback?
+     * For DB efficiency, requires submission and coursework objects to be passed in here, both usually already held by caller.
+     * Otherwise, on the grading page, there are repeated queries to get submission from ID.
+     * @param submission $submission
+     * @return bool
+     */
+    public function can_edit(coursework $coursework, submission $submission): bool {
+        return $this->can($coursework, $submission, 'edit');
+    }
+
+    /**
+     * Checks whether can with the ability class e.g. $ability->can('new', $feedback).
+     * @param coursework $coursework
+     * @param submission $submission
+     * @param string $action
+     * @return bool
+     */
+    public function can(coursework $coursework, submission $submission, string $action): bool {
+        global $USER;
+        if (!in_array($action, ['show', 'edit'])) {
+            throw new invalid_parameter_exception("Invalid action $action");
+        }
+
+        // For DB efficiency, ensure that $this->submission set before calling ability class.
+        $this->set_submission($submission);
+        $ability = new ability($USER->id, $coursework);
+        // If required, reason for refusal can be seen here with $ability->get_last_message().
+        return $ability->can($action, $this);
+    }
+
+    /**
+     * Set the submission object for this feedback.
+     * @param submission $submission
+     * @return void
+     */
+    private function set_submission(submission $submission) {
+        if (!isset($this->submission)) {
+            $this->submission = $submission;
+            $this->submissionid = $submission->id;
+        }
     }
 }

--- a/classes/models/user.php
+++ b/classes/models/user.php
@@ -144,21 +144,6 @@ class user extends table_base implements allocatable, moderatable {
     }
 
     /**
-     * Get user picture.
-     *
-     * @param int $size
-     * @return string
-     * @throws \core\exception\coding_exception
-     * @throws \dml_exception
-     */
-    public function get_user_picture_url(int $size = 100): string {
-        global $PAGE;
-        $userpicture = new user_picture($this->get_raw_record());
-        $userpicture->size = $size;
-        return $userpicture->get_url($PAGE)->out(false);
-    }
-
-    /**
      * Get user picture URL as string without going to database.
      * @param int|null $usercontextid
      * @param int|null $rev mdl_user.picture value (falsey = no image, +ve value = revision num to avoid browser caching problems).

--- a/classes/render_helpers/grading_report/data/marking_cell_data.php
+++ b/classes/render_helpers/grading_report/data/marking_cell_data.php
@@ -94,7 +94,8 @@ class marking_cell_data extends cell_data_base {
         ) {
             $marker->markerid = $assessor->id();
             $marker->markername = $assessor->name();
-            $marker->markerimg = $assessor->get_user_picture_url();
+            // Marker image "markerimg" is not set here as it would involve an extra DB query.
+            $marker->picture = $assessor->picture;
             $marker->markerurl = $assessor->get_user_profile_url();
             $marker->markeridentifier = sprintf('marker-%d', $assessor->id());
         } else {

--- a/classes/render_helpers/grading_report/data/marking_cell_data.php
+++ b/classes/render_helpers/grading_report/data/marking_cell_data.php
@@ -117,7 +117,9 @@ class marking_cell_data extends cell_data_base {
      */
     private function process_feedback_data(stdClass $marker, feedback $feedback, grading_table_row_base $rowsbase, assessor_feedback_row $row): void {
         // Get feedback mark.
-        $marker->mark = $this->get_mark_for_feedback($feedback);
+
+        $canshow = $feedback->can_show($this->coursework, $rowsbase->get_submission());
+        $marker->mark = $this->get_mark_for_feedback($feedback, $canshow);
         // Return early if no marking.
         if (!isset($marker->mark) || ($marker->mark === '')) {
             return;
@@ -131,10 +133,10 @@ class marking_cell_data extends cell_data_base {
 
         // Actions - show, edit.
         $action = null;
-        if ($this->ability->can('show', $feedback)) {
+        if ($canshow) {
             $action = 'show';
         }
-        if ($this->ability->can('edit', $feedback)) {
+        if ($feedback->can_edit($this->coursework, $rowsbase->get_submission())) {
             $action = 'edit';
             $marker->feedbackid = $feedback->id;
         }
@@ -196,7 +198,10 @@ class marking_cell_data extends cell_data_base {
                 $this->process_feedback_data($marker, $feedback, $rowsbase, $row);
             }
 
-            if ($this->can_add_new_feedback($row, $rowsbase)) {
+            $canaddfeedback = !$feedback
+                && $rowsbase->get_submission()
+                && feedback::can_add_new($rowsbase->get_coursework(), $rowsbase->get_submission(), $row->get_stage()->identifier());
+            if ($canaddfeedback) {
                 $marker->addfeedback = (object)[
                     'markurl' => $this->get_mark_url(
                         'new',
@@ -260,64 +265,19 @@ class marking_cell_data extends cell_data_base {
     }
 
     /**
-     * Check if the user can add a new feedback.
-     *
-     * @param assessor_feedback_row $feedbackrow
-     * @param grading_table_row_base $rowsbase
-     * @return bool
-     */
-    public function can_add_new_feedback(assessor_feedback_row $feedbackrow, grading_table_row_base $rowsbase): bool {
-        global $USER;
-
-        if (!$rowsbase->get_submission()) {
-            return false;
-        }
-
-        $feedbackparams = [
-            'submissionid' => $rowsbase->get_submission()->id,
-            'assessorid' => $USER->id,
-            'stageidentifier' => $feedbackrow->get_stage()->identifier(),
-        ];
-
-        return $this->ability->can('new', feedback::build($feedbackparams));
-    }
-
-    /**
-     * Check if the user can add a new final feedback.
-     *
-     * @param final_agreed $finalstage
-     * @param grading_table_row_base $rowsbase
-     * @return bool
-     */
-    public function can_add_new_final_feedback(final_agreed $finalstage, grading_table_row_base $rowsbase): bool {
-        global $USER;
-
-        if (!$rowsbase->get_submission()) {
-            return false;
-        }
-
-        $newfeedback = feedback::build([
-            'submissionid' => $rowsbase->get_submission()->id,
-            'assessorid' => $USER->id,
-            'stageidentifier' => $finalstage->identifier(),
-        ]);
-
-        return $this->ability->can('new', $newfeedback);
-    }
-
-    /**
      * Get the mark for a particular feedback.
      *
      * @param feedback $feedback
+     * @param bool $canshow
      * @return ?string
      * @throws coding_exception
      */
-    public function get_mark_for_feedback(feedback $feedback): ?string {
+    public function get_mark_for_feedback(feedback $feedback, bool $canshow): ?string {
         global $USER;
 
         $judge = new grade_judge($this->coursework);
 
-        if ($this->ability->can('show', $feedback) || is_siteadmin($USER->id)) {
+        if ($canshow || is_siteadmin($USER->id)) {
             return $judge->grade_to_display($feedback->get_grade());
         }
 
@@ -341,10 +301,12 @@ class marking_cell_data extends cell_data_base {
      * @throws dml_exception
      */
     public function get_final_feedback_data(grading_table_row_base $rowsbase): ?stdClass {
+        if (!$rowsbase->get_submission()) {
+            return null;
+        }
         // Early return if sampling is enabled but no sampled feedback exists.
         if (
             $rowsbase->get_coursework()->sampling_enabled() &&
-            $rowsbase->get_submission() &&
             !$rowsbase->get_submission()->sampled_feedback_exists()
         ) {
             return null;
@@ -352,21 +314,24 @@ class marking_cell_data extends cell_data_base {
 
         $finalstage = $this->coursework->get_final_agreed_marking_stage();
         $finalfeedback = $finalstage->get_feedback_for_allocatable($rowsbase->get_allocatable());
-
         if ($finalfeedback === false) {
             // Handle case when no feedback exists yet.
-            return $this->can_add_new_final_feedback($finalstage, $rowsbase) ?
-                (object)['addfinalfeedback' => (object)[
-                    'url' => $this->get_mark_url('new', $rowsbase->get_submission(), $finalstage, null, true),
-                    'allocatablehash' => $this->get_allocatable_hash($rowsbase->get_allocatable()),
-                ]] :
-                null;
+            return feedback::can_add_new($this->coursework, $rowsbase->get_submission(), $finalstage->identifier())
+                ? (object)[
+                    'addfinalfeedback' => (object)[
+                        'url' => $this->get_mark_url('new', $rowsbase->get_submission(), $finalstage, null, true),
+                        'allocatablehash' => $this->get_allocatable_hash($rowsbase->get_allocatable()),
+                    ],
+                ]
+                : null;
         }
 
         // Handle existing feedback.
-        $finalgrade = $this->get_mark_for_feedback($finalfeedback);
-        $action = $this->ability->can('edit', $finalfeedback) ? 'edit' :
-                 ($this->ability->can('show', $finalfeedback) ? 'show' : null);
+        $canshow = $finalfeedback->can_show($this->coursework, $rowsbase->get_submission());
+        $finalgrade = $this->get_mark_for_feedback($finalfeedback, $canshow);
+        $action = $finalfeedback->can_edit($this->coursework, $rowsbase->get_submission())
+            ? 'edit'
+            : ($canshow ? 'show' : null);
 
         // If this is an auto generated feedback, lasteditedbyuser will be zero.
         $assessorname = $finalfeedback->lasteditedbyuser

--- a/classes/renderers/grading_report_renderer.php
+++ b/classes/renderers/grading_report_renderer.php
@@ -25,6 +25,7 @@ namespace mod_coursework\renderers;
 use context_user;
 use core\exception\moodle_exception;
 use core\output\plugin_renderer_base;
+use core\output\user_picture;
 use mod_coursework\ability;
 use mod_coursework\grading_report;
 use mod_coursework\grading_table_row_base;
@@ -107,6 +108,8 @@ class grading_report_renderer extends plugin_renderer_base {
                 // Dropdown filter markers array by id to ensure unique.
                 foreach ($trdata->markers as $marker) {
                     if (isset($marker->markerid)) {
+                        $usercontextid = $participantcontextids[$marker->markerid] ?? null;
+                        $marker->markerimg = user::get_picture_url_from_context_id($usercontextid, $marker->picture);
                         $markersarray[$marker->markerid] = $marker;
                     }
                 }

--- a/classes/stages/base.php
+++ b/classes/stages/base.php
@@ -695,7 +695,6 @@ abstract class base {
         $currentstage = false;
         $currentstageok = true;
         $courseworkid = $this->get_courseworkid();
-        submission::fill_pool_coursework($courseworkid);
 
         foreach ($allstages as $stage) {
             // if coursework has sampling enabled, each stage must be checked if it uses sampling

--- a/classes/test_helpers/factory_mixin.php
+++ b/classes/test_helpers/factory_mixin.php
@@ -270,6 +270,7 @@ trait factory_mixin {
         $feedback->assessorid = 11; // Dummy
         $feedback->stageidentifier = 'final_agreed_1';
         $feedback->grade = 45;
+        $feedback->finalised = 1;
         $this->finalfeedback = $generator->create_feedback($feedback);
 
         return $this->finalfeedback;
@@ -289,6 +290,7 @@ trait factory_mixin {
         $feedback->assessorid = $assessor->id;
         $feedback->stageidentifier = 'assessor_' . ($count + 1);
         $feedback->grade = 45;
+        $feedback->finalised = 1;
         return $generator->create_feedback($feedback);
     }
 

--- a/renderers/object_renderer.php
+++ b/renderers/object_renderer.php
@@ -94,7 +94,9 @@ class mod_coursework_object_renderer extends plugin_renderer_base {
 
             // Marker image.
             if ($feedback->assessor) {
-                $template->markerimg = $feedback->assessor()->get_user_picture_url();
+                $userpicture = new user_picture($feedback->assessor()->get_raw_record());
+                $userpicture->size = 100;
+                $template->markerimg = $userpicture->get_url($this->page)->out(false);
             }
         }
 

--- a/renderers/page_renderer.php
+++ b/renderers/page_renderer.php
@@ -316,7 +316,7 @@ class mod_coursework_page_renderer extends plugin_renderer_base {
         if ($areagreeing && !$feedback->get_coursework()->is_using_advanced_grading()) {
             $feedbacks = [];
             $modcourseworkobjectrenderer = new mod_coursework_object_renderer($this->page, $this->target);
-            foreach ($feedback->submission->get_assessor_feedbacks() as $previousfeedbacks) {
+            foreach ($feedback->get_submission()->get_assessor_feedbacks() as $previousfeedbacks) {
                 $feedbacks[] = $modcourseworkobjectrenderer->render_feedback($previousfeedbacks, false);
             }
 

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -157,7 +157,7 @@ class mod_coursework_generator extends testing_module_generator {
 
         global $USER;
 
-        $feedback = \mod_coursework\models\feedback::build($feedback);
+        $feedback = \mod_coursework\models\feedback::create($feedback);
 
         if (!isset($feedback->submissionid) || !is_numeric($feedback->submissionid) || empty($feedback->submissionid)) {
             throw new coding_exception('Coursework generator needs a submissionid for a new feedback');

--- a/tests/phpunit/auto_grader/average_grade_no_straddle_test.php
+++ b/tests/phpunit/auto_grader/average_grade_no_straddle_test.php
@@ -101,19 +101,22 @@ final class average_grade_no_straddle_test extends \advanced_testcase {
             ->with($this->get_coursework())
             ->will($this->returnValue(true));
 
+        $submission = $this->createMock('\mod_coursework\models\submission');
+        $user->expects($this->any())->method('get_submission')
+            ->with($this->anything())
+            ->will($this->returnValue($submission));
+
         $feedbackone = $this->createMock('\mod_coursework\models\feedback');
         $feedbackone->expects($this->any())->method('get_grade')->will($this->returnValue($gradeone));
+        $feedbackone->expects($this->any())->method('get_submission')->will($this->returnValue($submission));
 
         $feedbacktwo = $this->createMock('\mod_coursework\models\feedback');
         $feedbacktwo->expects($this->any())->method('get_grade')->will($this->returnValue($gradetwo));
+        $feedbacktwo->expects($this->any())->method('get_submission')->will($this->returnValue($submission));
 
         $user->expects($this->any())->method('get_initial_feedbacks')
             ->with($this->get_coursework())
             ->will($this->returnValue([$feedbackone, $feedbacktwo]));
-
-        $submission = $this->createMock('\mod_coursework\models\submission');
-
-        $user->expects($this->any())->method('get_submission')->will($this->returnValue($submission));
 
         $autograder = new average_grade_no_straddle($this->get_coursework(), $user);
         $autograder->create_auto_grade_if_rules_match();

--- a/tests/phpunit/auto_grader/percentage_distance_test.php
+++ b/tests/phpunit/auto_grader/percentage_distance_test.php
@@ -86,20 +86,26 @@ final class percentage_distance_test extends \advanced_testcase {
             ->with($this->get_coursework())
             ->will($this->returnValue(true));
 
+        $submission = $this->createMock('\mod_coursework\models\submission');
+        $user->expects($this->any())->method('get_submission')
+            ->with($this->anything())
+            ->will($this->returnValue($submission));
+
         $feedbackone = $this->createMock('\mod_coursework\models\feedback');
         $feedbackone->expects($this->any())->method('get_grade')->will($this->returnValue(50));
+        $feedbackone->expects($this->any())->method('get_submission')->will($this->returnValue($submission));
 
         $feedbacktwo = $this->createMock('\mod_coursework\models\feedback');
         $feedbacktwo->expects($this->any())->method('get_grade')->will($this->returnValue(55));
+        $feedbacktwo->expects($this->any())->method('get_submission')->will($this->returnValue($submission));
 
         $user->expects($this->any())->method('get_initial_feedbacks')
             ->with($this->get_coursework())
             ->will($this->returnValue([$feedbackone, $feedbacktwo]));
 
-        $submission = $this->createMock('\mod_coursework\models\submission');
-        $submission->expects($this->any())->method('id')->will($this->returnValue(234234));
-
-        $user->expects($this->any())->method('get_submission')->will($this->returnValue($submission));
+        $user->expects($this->any())->method('get_submission')
+            ->with($this->anything())
+            ->will($this->returnValue($submission));
 
         $object = new percentage_distance($this->get_coursework(), $user);
         // Constructor percentage_distance no longer accepts percentage param since commit c1132f6, so set 10.
@@ -120,21 +126,23 @@ final class percentage_distance_test extends \advanced_testcase {
             ->with($this->get_coursework())
             ->will($this->returnValue(true));
 
+        $submission = $this->createMock('\mod_coursework\models\submission');
+
         $feedbackone = $this->createMock('\mod_coursework\models\feedback');
         $feedbackone->expects($this->any())->method('get_grade')->will($this->returnValue(50));
+        $feedbackone->expects($this->any())->method('get_submission')->will($this->returnValue($submission));
 
         $feedbacktwo = $this->createMock('\mod_coursework\models\feedback');
         $feedbacktwo->expects($this->any())->method('get_grade')->will($this->returnValue(55));
+        $feedbacktwo->expects($this->any())->method('get_submission')->will($this->returnValue($submission));
 
         $user->expects($this->any())->method('get_initial_feedbacks')
             ->with($this->get_coursework())
             ->will($this->returnValue([$feedbackone, $feedbacktwo]));
 
-        $submission = $this->createMock('\mod_coursework\models\submission');
-        $expectedsubmissionid = 234234;
-        $submission->expects($this->any())->method('id')->will($this->returnValue($expectedsubmissionid));
-
-        $user->expects($this->any())->method('get_submission')->will($this->returnValue($submission));
+        $user->expects($this->any())->method('get_submission')
+            ->with($this->anything())
+            ->will($this->returnValue($submission));
 
         $object = new percentage_distance($this->get_coursework(), $user);
         // Constructor percentage_distance no longer accepts percentage param since commit c1132f6, so set 10.
@@ -144,7 +152,6 @@ final class percentage_distance_test extends \advanced_testcase {
         $createdfeedbacks = $DB->get_records('coursework_feedbacks', [], 'id DESC', '*', 0, 1);
         $createdfeedback = reset($createdfeedbacks);
         $this->assertEquals($createdfeedback->grade ?? null, 55); // Right grade.
-        $this->assertEquals($createdfeedback->submissionid ?? null, $expectedsubmissionid); // Right submission.
         $this->assertEquals($createdfeedback->stageidentifier ?? null, 'final_agreed_1'); // Right stage.
     }
 }


### PR DESCRIPTION
- On the grading page, the ability class is passed a feedback object, and repeatedly calls $feedback->get_submission() which in turn calls the DB to get the related submission and sometimes coursework object from IDs.
- This is wasteful not least because when the ability class is called, the caller already has the submission object to hand
- Introduced feedback::can_add_new(), $feedback->can_edit() and $feedback->can_show() which improve this by ensuring that the submission object is set to the feedback object and avoids multiple DB queries per row
- also removed an unnecessary query to get marker's user picture