### PR TITLE
Ctp 5490 object exists cache

### DIFF
--- a/classes/ability.php
+++ b/classes/ability.php
@@ -281,10 +281,12 @@ class ability extends framework\ability {
             function (submission $submission) {
                 // Check using cached object to avoid repeated DB calls on grading page.
                 if (
-                    submission::get_object(
+                    submission::get_cached_object(
                         $submission->courseworkid,
-                        'allocatableid-allocatabletype',
-                        [$submission->allocatableid, $submission->allocatabletype]
+                        [
+                            'allocatableid' => $submission->allocatableid,
+                            'allocatabletype' => $submission->allocatabletype,
+                        ]
                     )
                 ) {
                     $this->set_message('Submission already exists');

--- a/classes/ability.php
+++ b/classes/ability.php
@@ -1449,10 +1449,12 @@ class ability extends framework\ability {
             'mod_coursework\models\deadline_extension',
             function (deadline_extension $deadlineextension) {
                 // Check using cached object to avoid repeated DB calls on grading page.
-                return (bool)deadline_extension::get_object(
+                return (bool)deadline_extension::get_cached_object(
                     $deadlineextension->courseworkid,
-                    'allocatableid-allocatabletype',
-                    [$deadlineextension->allocatableid, $deadlineextension->allocatabletype]
+                    [
+                        'allocatableid' => $deadlineextension->allocatableid,
+                        'allocatabletype' => $deadlineextension->allocatabletype,
+                    ]
                 );
             }
         );

--- a/classes/ability.php
+++ b/classes/ability.php
@@ -279,12 +279,14 @@ class ability extends framework\ability {
             'new',
             'mod_coursework\models\submission',
             function (submission $submission) {
-                $existsparams = [
-                    'courseworkid' => $submission->courseworkid,
-                    'allocatableid' => $submission->allocatableid,
-                    'allocatabletype' => $submission->allocatabletype,
-                ];
-                if (submission::exists($existsparams)) {
+                // Check using cached object to avoid repeated DB calls on grading page.
+                if (
+                    submission::get_object(
+                        $submission->courseworkid,
+                        'allocatableid,allocatabletype',
+                        [$submission->allocatableid, $submission->allocatabletype]
+                    )
+                ) {
                     $this->set_message('Submission already exists');
                     return true;
                 }
@@ -369,8 +371,11 @@ class ability extends framework\ability {
             'show',
             'mod_coursework\models\submission',
             function (submission $submission) {
-                return feedback::exists(
-                    ['submissionid' => $submission->id, 'assessorid' => $this->userid]
+                // Check using cached object to avoid repeated DB calls on grading page.
+                return (bool)feedback::get_object(
+                    $submission->get_coursework()->id(),
+                    'submissionid-assessorid',
+                    [$submission->id(), $this->userid]
                 );
             }
         );
@@ -1238,16 +1243,12 @@ class ability extends framework\ability {
             'show',
             'mod_coursework\grading_table_row_base',
             function (grading_table_row_base $gradingtablerow) {
-                if ($gradingtablerow->has_submission()) {
-                    if (
-                        feedback::exists(
-                            ['submissionid' => $gradingtablerow->get_submission()->id, 'assessorid' => $this->userid]
-                        )
-                    ) {
-                        return true;
-                    }
-                }
-                return false;
+                // Check using cached object to avoid repeated DB calls on grading page.
+                return $gradingtablerow->has_submission() && feedback::get_object(
+                    $gradingtablerow->get_coursework()->id(),
+                    'submissionid-assessorid',
+                    [$gradingtablerow->get_submission()->id(), $this->userid]
+                );
             }
         );
     }
@@ -1443,12 +1444,12 @@ class ability extends framework\ability {
             'new',
             'mod_coursework\models\deadline_extension',
             function (deadline_extension $deadlineextension) {
-                $conditions = [
-                    'allocatableid' => $deadlineextension->allocatableid,
-                    'allocatabletype' => $deadlineextension->allocatabletype,
-                    'courseworkid' => $deadlineextension->courseworkid,
-                ];
-                return deadline_extension::exists($conditions);
+                // Check using cached object to avoid repeated DB calls on grading page.
+                return (bool)deadline_extension::get_object(
+                    $deadlineextension->courseworkid,
+                    'allocatableid,allocatabletype',
+                    [$deadlineextension->allocatableid, $deadlineextension->allocatabletype]
+                );
             }
         );
     }

--- a/classes/ability.php
+++ b/classes/ability.php
@@ -374,10 +374,9 @@ class ability extends framework\ability {
             'mod_coursework\models\submission',
             function (submission $submission) {
                 // Check using cached object to avoid repeated DB calls on grading page.
-                return (bool)feedback::get_object(
+                return (bool)feedback::get_cached_object(
                     $submission->get_coursework()->id(),
-                    'submissionid-assessorid',
-                    [$submission->id(), $this->userid]
+                    ['submissionid' => $submission->id(), 'assessorid' => $this->userid]
                 );
             }
         );
@@ -1246,11 +1245,14 @@ class ability extends framework\ability {
             'mod_coursework\grading_table_row_base',
             function (grading_table_row_base $gradingtablerow) {
                 // Check using cached object to avoid repeated DB calls on grading page.
-                return $gradingtablerow->has_submission() && feedback::get_object(
-                    $gradingtablerow->get_coursework()->id(),
-                    'submissionid-assessorid',
-                    [$gradingtablerow->get_submission()->id(), $this->userid]
-                );
+                return $gradingtablerow->has_submission()
+                    && feedback::get_cached_object(
+                        $gradingtablerow->get_coursework()->id(),
+                        [
+                            'submissionid' => $gradingtablerow->get_submission()->id(),
+                            'assessorid' => $this->userid,
+                        ],
+                    );
             }
         );
     }

--- a/classes/ability.php
+++ b/classes/ability.php
@@ -283,7 +283,7 @@ class ability extends framework\ability {
                 if (
                     submission::get_object(
                         $submission->courseworkid,
-                        'allocatableid,allocatabletype',
+                        'allocatableid-allocatabletype',
                         [$submission->allocatableid, $submission->allocatabletype]
                     )
                 ) {
@@ -1447,7 +1447,7 @@ class ability extends framework\ability {
                 // Check using cached object to avoid repeated DB calls on grading page.
                 return (bool)deadline_extension::get_object(
                     $deadlineextension->courseworkid,
-                    'allocatableid,allocatabletype',
+                    'allocatableid-allocatabletype',
                     [$deadlineextension->allocatableid, $deadlineextension->allocatabletype]
                 );
             }

--- a/classes/allocation/table/cell/builder.php
+++ b/classes/allocation/table/cell/builder.php
@@ -433,10 +433,9 @@ class builder {
     private function has_final_feedback() {
         submission::fill_pool_coursework($this->coursework->id);
         feedback::fill_pool_coursework($this->coursework->id);
-        $submission = submission::get_object(
+        $submission = submission::get_cached_object(
             $this->coursework->id,
-            'allocatableid-allocatabletype',
-            [$this->allocatable->id(), $this->allocatable->type()]
+            ['allocatableid' => $this->allocatable->id(), 'allocatabletype' => $this->allocatable->type()]
         );
         if ($submission) {
             $feedbacks = feedback::$pool[$this->coursework->id]['submissionid'][$submission->id] ?? [];
@@ -456,10 +455,9 @@ class builder {
      */
     private function get_submission() {
         submission::fill_pool_coursework($this->coursework->id);
-        return submission::get_object(
+        return submission::get_cached_object(
             $this->coursework->id,
-            'allocatableid-allocatabletype',
-            [$this->allocatable->id(), $this->allocatable->type()]
+            ['allocatableid' => $this->allocatable->id(), 'allocatabletype' => $this->allocatable->type()]
         );
     }
 }

--- a/classes/framework/table_base.php
+++ b/classes/framework/table_base.php
@@ -729,4 +729,21 @@ abstract class table_base {
         $cache = cache::make('mod_coursework', 'courseworkdata', ['id' => $courseworkid]);
         $cache->delete(static::$tablename);
     }
+
+
+    /**
+     *
+     * @param int $courseworkid
+     * @param array $params to search cache for
+     * @return static|null
+     * @throws \core\exception\coding_exception
+     */
+    public static function get_cached_object(int $courseworkid, array $params): ?static {
+        if (!isset(static::$pool[$courseworkid])) {
+            static::fill_pool_coursework($courseworkid);
+        }
+        $cachekeyone = implode('-', array_keys($params));
+        $cachekeytwo = implode('-', array_values($params));
+        return static::$pool[$courseworkid][$cachekeyone][$cachekeytwo][0] ?? null;
+    }
 }

--- a/classes/grade_judge.php
+++ b/classes/grade_judge.php
@@ -177,7 +177,10 @@ class grade_judge {
 
         if ($this->coursework->sampling_enabled()) {
             assessment_set_membership::fill_pool_coursework($this->coursework->id);
-            $record = assessment_set_membership::get_object($this->coursework->id, 'allocatableid-allocatabletype', [$allocatable->id(), $allocatable->type()]);
+            $record = assessment_set_membership::get_cached_object(
+                $this->coursework->id,
+                ['allocatableid' => $allocatable->id(), 'allocatabletype' => $allocatable->type()]
+            );
             return !empty($record);
         } else {
             return $this->coursework->has_multiple_markers();

--- a/classes/grading_table_row_base.php
+++ b/classes/grading_table_row_base.php
@@ -270,8 +270,13 @@ class grading_table_row_base implements user_row {
         if (!isset($this->submission)) {
             $allocatableid = $this->get_allocatable()->id();
             $allocatabletype = $this->get_allocatable()->type();
-            $params = [$allocatableid, $allocatabletype];
-            $this->submission = submission::get_object($this->get_courseworkid(), 'allocatableid-allocatabletype', $params);
+            $this->submission = submission::get_cached_object(
+                $this->get_courseworkid(),
+                [
+                    'allocatableid' => $allocatableid,
+                    'allocatabletype' => $allocatabletype,
+                ]
+            );
         }
 
         return $this->submission;

--- a/classes/models/allocation.php
+++ b/classes/models/allocation.php
@@ -102,7 +102,7 @@ class allocation extends table_base {
      * @return user
      */
     public function assessor() {
-        return user::get_object($this->assessorid);
+        return user::get_cached_object_from_id($this->assessorid);
     }
 
     /**

--- a/classes/models/allocation.php
+++ b/classes/models/allocation.php
@@ -182,22 +182,6 @@ class allocation extends table_base {
 
     /**
      *
-     * @param int $courseworkid
-     * @param $key
-     * @param $params
-     * @return bool
-     * @throws coding_exception
-     */
-    public static function get_object($courseworkid, $key, $params) {
-        if (!isset(self::$pool[$courseworkid])) {
-            self::fill_pool_coursework($courseworkid);
-        }
-        $valuekey = implode('-', $params);
-        return self::$pool[$courseworkid][$key][$valuekey][0] ?? false;
-    }
-
-    /**
-     *
      */
     protected function post_save_hook() {
         self::remove_cache($this->courseworkid);

--- a/classes/models/assessment_set_membership.php
+++ b/classes/models/assessment_set_membership.php
@@ -83,22 +83,6 @@ class assessment_set_membership extends table_base implements moderatable {
 
     /**
      *
-     * @param int $courseworkid
-     * @param $key
-     * @param $params
-     * @return mixed
-     * @throws coding_exception
-     */
-    public static function get_object($courseworkid, $key, $params) {
-        if (!isset(self::$pool[$courseworkid])) {
-            self::fill_pool_coursework($courseworkid);
-        }
-        $valuekey = implode('-', $params);
-        return self::$pool[$courseworkid][$key][$valuekey][0] ?? false;
-    }
-
-    /**
-     *
      */
     protected function post_save_hook() {
         self::remove_cache($this->courseworkid);

--- a/classes/models/coursework.php
+++ b/classes/models/coursework.php
@@ -2606,7 +2606,10 @@ class coursework extends table_base {
 
         if ($this->personaldeadlines_enabled()) {
             personaldeadline::fill_pool_coursework($this->id);
-            $deadlinerecord = personaldeadline::get_object($this->id, 'allocatableid-allocatabletype', [$allocatable->id, $allocatable->type()]);
+            $deadlinerecord = personaldeadline::get_cached_object(
+                $this->id,
+                ['allocatableid' => $allocatable->id, 'allocatabletype' => $allocatable->type()]
+            );
 
             if (!empty($deadlinerecord)) {
                 $allocatable->deadline = $deadlinerecord->personaldeadline;

--- a/classes/models/coursework.php
+++ b/classes/models/coursework.php
@@ -2983,7 +2983,7 @@ class coursework extends table_base {
      * @return bool
      * @throws dml_exception
      */
-    public static function get_object($courseworkid) {
+    public static function get_cached_object_from_id($courseworkid) {
         if (!isset(self::$pool['id'][$courseworkid])) {
             self::fill_pool_coursework($courseworkid);
         }

--- a/classes/models/coursework.php
+++ b/classes/models/coursework.php
@@ -554,7 +554,10 @@ class coursework extends table_base {
         $submissions = submission::$pool[$this->id]['id'];
         $count = 0;
         foreach ($submissions as $s) {
-            $feedback = feedback::get_object($this->id, 'submissionid-assessorid', [$s->id, $USER->id]);
+            $feedback = feedback::get_cached_object(
+                $this->id,
+                ['submissionid' => $s->id, 'assessorid' => $USER->id]
+            );
             if (empty($feedback)) {
                 $count++;
             }

--- a/classes/models/deadline_extension.php
+++ b/classes/models/deadline_extension.php
@@ -106,7 +106,7 @@ class deadline_extension extends table_base {
      */
     public function get_coursework() {
         if (!isset($this->coursework)) {
-            $this->coursework = coursework::get_object($this->courseworkid);
+            $this->coursework = coursework::get_cached_object_from_id($this->courseworkid);
         }
 
         return $this->coursework;

--- a/classes/models/deadline_extension.php
+++ b/classes/models/deadline_extension.php
@@ -64,7 +64,13 @@ class deadline_extension extends table_base {
      */
     public static function allocatable_extension_allows_submission($allocatable, $coursework) {
         self::fill_pool_coursework($coursework->id);
-        $extension = self::get_object($coursework->id, 'allocatableid-allocatabletype', [$allocatable->id(), $allocatable->type()]);
+        $extension = self::get_cached_object(
+            $coursework->id,
+            [
+                'allocatableid' => $allocatable->id(),
+                'allocatabletype' => $allocatable->type()
+            ]
+        );
 
         return !empty($extension) && $extension->extended_deadline > time();
     }
@@ -85,7 +91,13 @@ class deadline_extension extends table_base {
         }
         if ($allocatable) {
             self::fill_pool_coursework($coursework->id);
-            return self::get_object($coursework->id, 'allocatableid-allocatabletype', [$allocatable->id(), $allocatable->type()]);
+            return self::get_cached_object(
+                $coursework->id,
+                [
+                    'allocatableid' => $allocatable->id(),
+                    'allocatabletype' => $allocatable->type()
+                ]
+            ) ?? false;
         }
     }
 

--- a/classes/models/deadline_extension.php
+++ b/classes/models/deadline_extension.php
@@ -152,22 +152,6 @@ class deadline_extension extends table_base {
 
     /**
      *
-     * @param int $courseworkid
-     * @param $key
-     * @param $params
-     * @return mixed
-     * @throws coding_exception
-     */
-    public static function get_object($courseworkid, $key, $params) {
-        if (!isset(self::$pool[$courseworkid])) {
-            self::fill_pool_coursework($courseworkid);
-        }
-        $valuekey = implode('-', $params);
-        return self::$pool[$courseworkid][$key][$valuekey][0] ?? false;
-    }
-
-    /**
-     *
      */
     protected function post_save_hook() {
         self::remove_cache($this->courseworkid);

--- a/classes/models/deadline_extension.php
+++ b/classes/models/deadline_extension.php
@@ -68,7 +68,7 @@ class deadline_extension extends table_base {
             $coursework->id,
             [
                 'allocatableid' => $allocatable->id(),
-                'allocatabletype' => $allocatable->type()
+                'allocatabletype' => $allocatable->type(),
             ]
         );
 
@@ -95,7 +95,7 @@ class deadline_extension extends table_base {
                 $coursework->id,
                 [
                     'allocatableid' => $allocatable->id(),
-                    'allocatabletype' => $allocatable->type()
+                    'allocatabletype' => $allocatable->type(),
                 ]
             ) ?? false;
         }

--- a/classes/models/feedback.php
+++ b/classes/models/feedback.php
@@ -208,7 +208,7 @@ class feedback extends table_base {
      */
     public function get_assesor_username() {
         if (!$this->firstname && !empty($this->lasteditedbyuser)) {
-            $this->assessor = user::get_object($this->lasteditedbyuser);
+            $this->assessor = user::get_cached_object_from_id($this->lasteditedbyuser);
         }
 
         return $this->assessor->name();
@@ -549,7 +549,7 @@ class feedback extends table_base {
      * @return user
      */
     public function assessor() {
-        return user::get_object($this->assessorid);
+        return user::get_cached_object_from_id($this->assessorid);
     }
 
     /**

--- a/classes/models/feedback.php
+++ b/classes/models/feedback.php
@@ -664,22 +664,6 @@ class feedback extends table_base {
 
     /**
      *
-     * @param int $courseworkid
-     * @param $key
-     * @param $params
-     * @return self|bool
-     * @throws dml_exception
-     */
-    public static function get_object($courseworkid, $key, $params) {
-        if (!isset(self::$pool[$courseworkid])) {
-            self::fill_pool_coursework($courseworkid);
-        }
-        $valuekey = implode('-', $params);
-        return self::$pool[$courseworkid][$key][$valuekey][0] ?? false;
-    }
-
-    /**
-     *
      */
     protected function post_save_hook() {
         $submission = $this->get_submission();

--- a/classes/models/group.php
+++ b/classes/models/group.php
@@ -133,11 +133,12 @@ class group extends table_base implements allocatable, moderatable {
     }
 
     /**
-     * @param $id
-     * @return mixed
+     * Get the cached group object from its ID.
+     * @param int $id
+     * @return group|false
      * @throws \dml_exception
      */
-    public static function get_object($id) {
+    public static function get_cached_object_from_id(int $id) {
         if (!isset(self::$pool['id'][$id])) {
             global $DB;
             $user = $DB->get_record(self::$tablename, ['id' => $id]);

--- a/classes/models/moderation.php
+++ b/classes/models/moderation.php
@@ -148,7 +148,7 @@ class moderation extends table_base {
      * @return user
      */
     public function moderator() {
-        return user::get_object($this->moderatorid);
+        return user::get_cached_object_from_id($this->moderatorid);
     }
 
     /**

--- a/classes/models/personaldeadline.php
+++ b/classes/models/personaldeadline.php
@@ -61,7 +61,7 @@ class personaldeadline extends table_base {
     public function get_coursework() {
         if (!isset($this->coursework)) {
             coursework::fill_pool_coursework($this->courseworkid);
-            $this->coursework = coursework::get_object($this->courseworkid);
+            $this->coursework = coursework::get_cached_object_from_id($this->courseworkid);
         }
 
         return $this->coursework;

--- a/classes/models/personaldeadline.php
+++ b/classes/models/personaldeadline.php
@@ -140,22 +140,6 @@ class personaldeadline extends table_base {
 
     /**
      *
-     * @param int $courseworkid
-     * @param $key
-     * @param $params
-     * @return mixed
-     * @throws coding_exception
-     */
-    public static function get_object($courseworkid, $key, $params) {
-        if (!isset(self::$pool[$courseworkid])) {
-            self::fill_pool_coursework($courseworkid);
-        }
-        $valuekey = implode('-', $params);
-        return self::$pool[$courseworkid][$key][$valuekey][0] ?? false;
-    }
-
-    /**
-     *
      */
     protected function post_save_hook() {
         self::remove_cache($this->courseworkid);

--- a/classes/models/plagiarism_flag.php
+++ b/classes/models/plagiarism_flag.php
@@ -64,7 +64,7 @@ class plagiarism_flag extends table_base {
     public function get_coursework() {
         if (!isset($this->coursework)) {
             coursework::fill_pool_coursework($this->courseworkid);
-            $this->coursework = coursework::get_object($this->courseworkid);
+            $this->coursework = coursework::get_cached_object_from_id($this->courseworkid);
         }
 
         return $this->coursework;

--- a/classes/models/plagiarism_flag.php
+++ b/classes/models/plagiarism_flag.php
@@ -88,12 +88,14 @@ class plagiarism_flag extends table_base {
 
     /**
      * @param $submission
-     * @return static
+     * @return ?static
      * @throws coding_exception
      */
     public static function get_plagiarism_flag($submission) {
         self::fill_pool_coursework($submission->courseworkid);
-        return self::get_object($submission->courseworkid, 'submissionid', [$submission->id]);
+        return self::get_cached_object(
+            $submission->courseworkid, ['submissionid' => $submission->id]
+        );
     }
 
     /**
@@ -137,22 +139,6 @@ class plagiarism_flag extends table_base {
             }
         }
         return $result;
-    }
-
-    /**
-     *
-     * @param int $courseworkid
-     * @param $key
-     * @param $params
-     * @return self|bool
-     * @throws coding_exception
-     */
-    public static function get_object($courseworkid, $key, $params) {
-        if (!isset(self::$pool[$courseworkid])) {
-            self::fill_pool_coursework($courseworkid);
-        }
-        $valuekey = implode('-', $params);
-        return self::$pool[$courseworkid][$key][$valuekey][0] ?? false;
     }
 
     /**

--- a/classes/models/plagiarism_flag.php
+++ b/classes/models/plagiarism_flag.php
@@ -94,7 +94,8 @@ class plagiarism_flag extends table_base {
     public static function get_plagiarism_flag($submission) {
         self::fill_pool_coursework($submission->courseworkid);
         return self::get_cached_object(
-            $submission->courseworkid, ['submissionid' => $submission->id]
+            $submission->courseworkid,
+            ['submissionid' => $submission->id]
         );
     }
 

--- a/classes/models/submission.php
+++ b/classes/models/submission.php
@@ -1596,22 +1596,6 @@ class submission extends table_base implements renderable {
 
     /**
      *
-     * @param int $courseworkid
-     * @param $key
-     * @param $params
-     * @return self|bool
-     * @throws \core\exception\coding_exception
-     */
-    public static function get_object($courseworkid, $key, $params) {
-        if (!isset(self::$pool[$courseworkid])) {
-            self::fill_pool_coursework($courseworkid);
-        }
-        $valuekey = implode('-', $params);
-        return self::$pool[$courseworkid][$key][$valuekey][0] ?? false;
-    }
-
-    /**
-     *
      */
     protected function post_save_hook() {
         self::remove_cache($this->courseworkid);

--- a/classes/models/submission.php
+++ b/classes/models/submission.php
@@ -1038,7 +1038,9 @@ class submission extends table_base implements renderable {
         if ($this->get_coursework()->plagiarism_flagging_enabled()) {
             // check if not stopped by plagiarism flag
             plagiarism_flag::fill_pool_coursework($this->courseworkid);
-            $plagiarism = plagiarism_flag::get_object($this->courseworkid, 'submissionid', [$this->id]);
+            $plagiarism = plagiarism_flag::get_cached_object(
+                $this->courseworkid, ['submissionid' => $this->id]
+            );
             if ($plagiarism && !$plagiarism->can_release_grades()) {
                 return false;
             }

--- a/classes/models/submission.php
+++ b/classes/models/submission.php
@@ -1410,7 +1410,10 @@ class submission extends table_base implements renderable {
     public function submission_personaldeadline() {
         $allocatableid = $this->get_allocatable()->id();
         $allocatabletype = $this->get_allocatable()->type();
-        $personaldeadline = personaldeadline::get_object($this->courseworkid, 'allocatableid-allocatabletype', [$allocatableid, $allocatabletype]);
+        $personaldeadline = personaldeadline::get_cached_object(
+            $this->courseworkid,
+            ['allocatableid' => $allocatableid, 'allocatabletype' => $allocatabletype]
+        );
 
         if ($personaldeadline) {
             $personaldeadline = $personaldeadline->personaldeadline;

--- a/classes/models/submission.php
+++ b/classes/models/submission.php
@@ -1350,16 +1350,19 @@ class submission extends table_base implements renderable {
     /**
      *  Function to get samplings for the submission
      * @param $stageidentifier
-     * @return array
+     * @return assessment_set_membership
      * @throws \core\exception\coding_exception
      */
 
     public function get_submissions_in_sample_by_stage($stageidentifier) {
         assessment_set_membership::fill_pool_coursework($this->courseworkid);
-        return assessment_set_membership::get_object(
+        return assessment_set_membership::get_cached_object(
             $this->courseworkid,
-            'allocatableid-allocatabletype-stageidentifier',
-            [$this->allocatableid, $this->allocatabletype, $stageidentifier]
+            [
+                'allocatableid' => $this->allocatableid,
+                'allocatabletype' => $this->allocatabletype,
+                'stageidentifier' => $stageidentifier,
+            ]
         );
     }
 

--- a/classes/models/submission.php
+++ b/classes/models/submission.php
@@ -749,7 +749,7 @@ class submission extends table_base implements renderable {
      * @return user
      */
     public function get_last_updated_by_user() {
-        return user::get_object($this->lastupdatedby);
+        return user::get_cached_object_from_id($this->lastupdatedby);
     }
 
     /**
@@ -1004,7 +1004,7 @@ class submission extends table_base implements renderable {
          * @var table_base $classname
          */
         $classname = "\\mod_coursework\\models\\" . $this->allocatabletype;
-        return $classname::get_object($this->allocatableid);
+        return $classname::get_cached_object_from_id($this->allocatableid);
     }
 
     /**
@@ -1120,13 +1120,6 @@ class submission extends table_base implements renderable {
         }
 
         return $grades;
-    }
-
-    /**
-     * @return user
-     */
-    public function get_last_submitter() {
-        return user::get_object($this->lastupdatedby);
     }
 
     /**

--- a/classes/models/submission.php
+++ b/classes/models/submission.php
@@ -547,7 +547,7 @@ class submission extends table_base implements renderable {
     /**
      * Function to retrieve a assessor allocated for the specific stage
      * @param $stageidentifier
-     * @return bool
+     * @return ?allocation
      * @throws coding_exception
      * @throws dml_exception
      */
@@ -555,10 +555,13 @@ class submission extends table_base implements renderable {
 
         $courseworkid = $this->get_coursework()->id;
         allocation::fill_pool_coursework($courseworkid);
-        return allocation::get_object(
+        return allocation::get_cached_object(
             $courseworkid,
-            'allocatableid-allocatabletype-stageidentifier',
-            [$this->get_allocatable()->id(), $this->get_allocatable()->type(), $stageidentifier]
+            [
+                'allocatableid' => $this->get_allocatable()->id(),
+                'allocatabletype' => $this->get_allocatable()->type(),
+                'stageidentifier' => $stageidentifier,
+            ]
         );
     }
 

--- a/classes/models/submission.php
+++ b/classes/models/submission.php
@@ -1039,7 +1039,8 @@ class submission extends table_base implements renderable {
             // check if not stopped by plagiarism flag
             plagiarism_flag::fill_pool_coursework($this->courseworkid);
             $plagiarism = plagiarism_flag::get_cached_object(
-                $this->courseworkid, ['submissionid' => $this->id]
+                $this->courseworkid,
+                ['submissionid' => $this->id]
             );
             if ($plagiarism && !$plagiarism->can_release_grades()) {
                 return false;

--- a/classes/models/user.php
+++ b/classes/models/user.php
@@ -217,11 +217,12 @@ class user extends table_base implements allocatable, moderatable {
     }
 
     /**
-     * @param $id
-     * @return self
+     * Get the cached user object from its ID.
+     * @param int $id
+     * @return self|false
      * @throws \dml_exception
      */
-    public static function get_object($id) {
+    public static function get_cached_object_from_id(int $id) {
         if (!isset(self::$pool['id'][$id])) {
             global $DB;
             $user = $DB->get_record(self::$tablename, ['id' => $id]);

--- a/classes/render_helpers/grading_report/data/student_cell_data.php
+++ b/classes/render_helpers/grading_report/data/student_cell_data.php
@@ -71,7 +71,7 @@ class student_cell_data extends cell_data_base {
         $data->id = $hidden ? '' : $group->id;
         $data->name = $group->name();
         $data->picture = $hidden ? '' :
-            get_group_picture_url($group->get_object($group->id()), $this->coursework->get_course_id());
+            get_group_picture_url(group::get_cached_object_from_id($group->id()), $this->coursework->get_course_id());
         $data->members = $this->get_group_members($group, $hidden);
         return $data;
     }

--- a/classes/renderers/grading_report_renderer.php
+++ b/classes/renderers/grading_report_renderer.php
@@ -208,7 +208,7 @@ class grading_report_renderer extends plugin_renderer_base {
     public static function export_one_row_data(coursework $coursework, int $allocatableid, string $allocatabletype): ?object {
         global $USER;
         $classname = "\\mod_coursework\\models\\$allocatabletype";
-        $allocatable = $classname::get_object($allocatableid);
+        $allocatable = $classname::get_cached_object_from_id($allocatableid);
         if (!$allocatable) {
             return null;
         }

--- a/classes/stages/base.php
+++ b/classes/stages/base.php
@@ -761,7 +761,7 @@ abstract class base {
         return feedback::get_cached_object(
             $submission->courseworkid,
             ['submissionid' => $submission->id, 'stageidentifier' => $stageidentifier]
-        );
+        ) ?? false;
     }
 
     /**

--- a/classes/stages/base.php
+++ b/classes/stages/base.php
@@ -991,7 +991,7 @@ abstract class base {
                     $assessor = array_column($user, 'id');
                     if ($assessor) {
                         $assessorid = $assessor[0];
-                        $assessor = user::get_object($assessorid);
+                        $assessor = user::get_cached_object_from_id($assessorid);
                         break;
                     }
                 }

--- a/classes/stages/base.php
+++ b/classes/stages/base.php
@@ -350,7 +350,10 @@ abstract class base {
         $submission = submission::get_cached_object($courseworkid, ['allocatableid' => $allocatable->id]);
         if ($submission) {
             feedback::fill_pool_coursework($courseworkid);
-            $feedback = feedback::get_object($courseworkid, 'submissionid-stageidentifier', [$submission->id, $this->identifier()]);
+            $feedback = feedback::get_cached_object(
+                $courseworkid,
+                ['submissionid' => $submission->id, 'stageidentifier' => $this->identifier()]
+            );
         }
         return !empty($feedback);
     }
@@ -416,7 +419,10 @@ abstract class base {
      */
     public function get_single_feedback($submission) {
         feedback::fill_pool_coursework($submission->courseworkid);
-        return feedback::get_object($submission->courseworkid, 'submissionid-stageidentifier', [$submission->id, 'assessor_1']);
+        return feedback::get_cached_object(
+            $submission->courseworkid,
+            ['submissionid' => $submission->id, 'stageidentifier' => 'assessor_1']
+        );
     }
 
     /**
@@ -751,7 +757,10 @@ abstract class base {
      */
     public function get_feedback_for_submission($submission) {
         $stageidentifier = $this->identifier();
-        return feedback::get_object($submission->courseworkid, 'submissionid-stageidentifier', [$submission->id, $stageidentifier]);
+        return feedback::get_cached_object(
+            $submission->courseworkid,
+            ['submissionid' => $submission->id, 'stageidentifier' => $stageidentifier]
+        );
     }
 
     /**

--- a/classes/stages/base.php
+++ b/classes/stages/base.php
@@ -546,10 +546,13 @@ abstract class base {
         }
 
         assessment_set_membership::fill_pool_coursework($this->coursework->id);
-        $record = assessment_set_membership::get_object(
+        $record = assessment_set_membership::get_cached_object(
             $this->coursework->id,
-            'allocatableid-allocatabletype-stageidentifier',
-            [$allocatable->id(), $allocatable->type(), $this->stageidentifier]
+            [
+                'allocatableid' => $allocatable->id(),
+                'allocatabletype' => $allocatable->type(),
+                'stageidentifier' => $this->stageidentifier,
+            ]
         );
         return !empty($record);
     }

--- a/classes/traits/allocatable_functions.php
+++ b/classes/traits/allocatable_functions.php
@@ -162,11 +162,14 @@ trait allocatable_functions {
 
     /**
      * @param $coursework
-     * @return bool
+     * @return ?submission
      */
     public function get_submission($coursework) {
         $this->fill_submission_and_feedback($coursework);
-        return submission::get_object($coursework->id, 'allocatableid', [$this->id]);
+        return submission::get_cached_object(
+            $coursework->id,
+            ['allocatableid' => $this->id]
+        );
     }
 
     /**

--- a/renderers/page_renderer.php
+++ b/renderers/page_renderer.php
@@ -212,7 +212,7 @@ class mod_coursework_page_renderer extends plugin_renderer_base {
             }
         }
 
-        if ($ability->can('new', $submission)) {
+        if (!$submission && $ability->can('new', $submission)) {
             if ($coursework->start_date_has_passed()) {
                 $template->submissionbutton = $this->new_submission_button($submission);
             }

--- a/renderers/page_renderer.php
+++ b/renderers/page_renderer.php
@@ -212,7 +212,7 @@ class mod_coursework_page_renderer extends plugin_renderer_base {
             }
         }
 
-        if (!$submission && $ability->can('new', $submission)) {
+        if ((!$submission || !$submission->persisted()) && $ability->can('new', $submission)) {
             if ($coursework->start_date_has_passed()) {
                 $template->submissionbutton = $this->new_submission_button($submission);
             }

--- a/tests/behat/file_renaming_basic.feature
+++ b/tests/behat/file_renaming_basic.feature
@@ -1,4 +1,4 @@
-@mod @mod_coursework @file_renaming
+@mod @mod_coursework @mod_coursework_file_renaming_basic
 Feature: Basic file renaming for submission files
 
   As a teacher

--- a/tests/behat/file_renaming_candidate.feature
+++ b/tests/behat/file_renaming_candidate.feature
@@ -1,4 +1,4 @@
-@mod @mod_coursework @file_renaming_candidate
+@mod @mod_coursework @mod_coursework_file_renaming_candidate
 Feature: Candidate number based file renaming for submission files
 
   As a teacher


### PR DESCRIPTION
In the ability class, to avoid repeated DB queries from the grading page, instead of feedback::exists(), submission::exists() and deadline_extension::exists(),  use get_object() for each class which uses cached data