### PR TITLE
CTP-5490 validate keys for get_cached_object()

### DIFF
--- a/classes/framework/table_base.php
+++ b/classes/framework/table_base.php
@@ -730,9 +730,39 @@ abstract class table_base {
         $cache->delete(static::$tablename);
     }
 
+    /**
+     * Check that any cache key being requested is valid (i.e. exists as valid cache key in child class).
+     * Otherwise, @see self::get_cached_object() will return null without complaining and no-one will notice.
+     * @param string $cachekey
+     * @return void
+     * @throws coding_exception
+     */
+    protected static function validate_cache_key(string $cachekey): void {
+        $validkeys = static::get_valid_cache_keys();
+        if (!in_array($cachekey, $validkeys)) {
+            throw new coding_exception(
+                "Requested cache key '$cachekey' invalid."
+                . " Must must be one of: " . implode(' | ', $validkeys)
+                . " (" . self::class . "::get_cached_object())"
+            );
+        }
+    }
 
     /**
+     * Get the allowed/expected cache keys for this class when @see self::get_cached_object() is called.
      *
+     * @return string[]
+     */
+    protected static function get_valid_cache_keys(): array {
+        throw new coding_exception(
+            "For validation, please implement get_valid_cache_keys() in child class '" . get_called_class()
+            . "' where get_cached_object() is used"
+        );
+    }
+
+    /**
+     * Get cached object for params provided.
+     * $params must use keys from child class get_valid_cache_keys()
      * @param int $courseworkid
      * @param array $params to search cache for
      * @return static|null
@@ -743,6 +773,7 @@ abstract class table_base {
             static::fill_pool_coursework($courseworkid);
         }
         $cachekeyone = implode('-', array_keys($params));
+        static::validate_cache_key($cachekeyone);
         $cachekeytwo = implode('-', array_values($params));
         return static::$pool[$courseworkid][$cachekeyone][$cachekeytwo][0] ?? null;
     }

--- a/classes/models/allocation.php
+++ b/classes/models/allocation.php
@@ -160,13 +160,7 @@ class allocation extends table_base {
     protected static function get_cache_array($courseworkid) {
         global $DB;
         $records = $DB->get_records(static::$tablename, ['courseworkid' => $courseworkid]);
-        $result = [
-            'id' => [],
-            'stageidentifier' => [],
-            'allocatableid-allocatabletype-stageidentifier' => [],
-            'allocatableid-allocatabletype-assessorid' => [],
-            'assessorid-allocatabletype' => [],
-        ];
+        $result = array_fill_keys(self::get_valid_cache_keys(), []);
         if ($records) {
             foreach ($records as $record) {
                 $object = new self($record);
@@ -178,6 +172,20 @@ class allocation extends table_base {
             }
         }
         return $result;
+    }
+
+    /**
+     * Get the allowed/expected cache keys for this class when @see self::get_cached_object() is called.
+     * @return string[]
+     */
+    protected static function get_valid_cache_keys(): array {
+        return [
+            'id',
+            'stageidentifier',
+            'allocatableid-allocatabletype-stageidentifier',
+            'allocatableid-allocatabletype-assessorid',
+            'assessorid-allocatabletype',
+        ];
     }
 
     /**

--- a/classes/models/assessment_set_membership.php
+++ b/classes/models/assessment_set_membership.php
@@ -65,11 +65,7 @@ class assessment_set_membership extends table_base implements moderatable {
     protected static function get_cache_array($courseworkid) {
         global $DB;
         $records = $DB->get_records(self::$tablename, ['courseworkid' => $courseworkid]);
-        $result = [
-            'allocatableid-allocatabletype' => [],
-            'allocatableid-allocatabletype-stageidentifier' => [],
-            'allocatableid-stageidentifier-selectiontype' => [],
-        ];
+        $result = array_fill_keys(self::get_valid_cache_keys(), []);
         if ($records) {
             foreach ($records as $record) {
                 $object = new self($record);
@@ -79,6 +75,18 @@ class assessment_set_membership extends table_base implements moderatable {
             }
         }
         return $result;
+    }
+
+    /**
+     * Get the allowed/expected cache keys for this class when @see self::get_cached_object() is called.
+     * @return string[]
+     */
+    protected static function get_valid_cache_keys(): array {
+        return [
+            'allocatableid-allocatabletype',
+            'allocatableid-allocatabletype-stageidentifier',
+            'allocatableid-stageidentifier-selectiontype',
+        ];
     }
 
     /**

--- a/classes/models/deadline_extension.php
+++ b/classes/models/deadline_extension.php
@@ -150,9 +150,7 @@ class deadline_extension extends table_base {
     protected static function get_cache_array($courseworkid) {
         global $DB;
         $records = $DB->get_records(static::$tablename, ['courseworkid' => $courseworkid]);
-        $result = [
-            'allocatableid-allocatabletype' => [],
-        ];
+        $result = array_fill_keys(self::get_valid_cache_keys(), []);
         if ($records) {
             foreach ($records as $record) {
                 $object = new self($record);
@@ -160,6 +158,14 @@ class deadline_extension extends table_base {
             }
         }
         return $result;
+    }
+
+    /**
+     * Get the allowed/expected cache keys for this class when @see self::get_cached_object() is called.
+     * @return string[]
+     */
+    protected static function get_valid_cache_keys(): array {
+        return ['allocatableid-allocatabletype'];
     }
 
     /**

--- a/classes/models/personaldeadline.php
+++ b/classes/models/personaldeadline.php
@@ -126,9 +126,7 @@ class personaldeadline extends table_base {
     protected static function get_cache_array($courseworkid) {
         global $DB;
         $records = $DB->get_records(static::$tablename, ['courseworkid' => $courseworkid]);
-        $result = [
-            'allocatableid-allocatabletype' => [],
-        ];
+        $result = array_fill_keys(self::get_valid_cache_keys(), []);
         if ($records) {
             foreach ($records as $record) {
                 $object = new self($record);
@@ -136,6 +134,14 @@ class personaldeadline extends table_base {
             }
         }
         return $result;
+    }
+
+    /**
+     * Get the allowed/expected cache keys for this class when @see self::get_cached_object() is called.
+     * @return string[]
+     */
+    protected static function get_valid_cache_keys(): array {
+        return ['allocatableid-allocatabletype'];
     }
 
     /**

--- a/classes/models/plagiarism_flag.php
+++ b/classes/models/plagiarism_flag.php
@@ -130,9 +130,7 @@ class plagiarism_flag extends table_base {
     protected static function get_cache_array($courseworkid) {
         global $DB;
         $records = $DB->get_records(self::$tablename, ['courseworkid' => $courseworkid]);
-        $result = [
-            'submissionid' => [],
-        ];
+        $result = array_fill_keys(self::get_valid_cache_keys(), []);
         if ($records) {
             foreach ($records as $record) {
                 $object = new self($record);
@@ -140,6 +138,14 @@ class plagiarism_flag extends table_base {
             }
         }
         return $result;
+    }
+
+    /**
+     * Get the allowed/expected cache keys for this class when @see self::get_cached_object() is called.
+     * @return string[]
+     */
+    protected static function get_valid_cache_keys(): array {
+        return ['submissionid'];
     }
 
     /**

--- a/classes/models/submission.php
+++ b/classes/models/submission.php
@@ -1590,12 +1590,7 @@ class submission extends table_base implements renderable {
     protected static function get_cache_array($courseworkid) {
         global $DB;
         $records = $DB->get_records(static::$tablename, ['courseworkid' => $courseworkid]);
-        $result = [
-            'id' => [],
-            'allocatableid' => [],
-            'finalisedstatus' => [],
-            'allocatableid-allocatabletype' => [],
-        ];
+        $result = array_fill_keys(self::get_valid_cache_keys(), []);
         if ($records) {
             foreach ($records as $record) {
                 $object = new self($record);
@@ -1606,6 +1601,19 @@ class submission extends table_base implements renderable {
             }
         }
         return $result;
+    }
+
+    /**
+     * Get the allowed/expected cache keys for this class when @see self::get_cached_object() is called.
+     * @return string[]
+     */
+    protected static function get_valid_cache_keys(): array {
+        return [
+            'id',
+            'allocatableid',
+            'finalisedstatus',
+            'allocatableid-allocatabletype',
+        ];
     }
 
     /**


### PR DESCRIPTION
- added validation of the array keys passed when get_cached_object() is called to table_base
- each child class which uses get_cached_object() (e.g. feedback, deadline_extension) must implement get_valid_cache_keys() which sets out they keys that are valid for that child class