### PR TITLE
Ctp 5571 empty mark

### DIFF
--- a/classes/forms/assessor_feedback_mform.php
+++ b/classes/forms/assessor_feedback_mform.php
@@ -132,6 +132,7 @@ class assessor_feedback_mform extends moodleform {
                 'grade',
                 $this->feedback->stageidentifier == final_agreed::STAGE_FINAL_AGREED_1 ? PARAM_LOCALISEDFLOAT : PARAM_INT
             );
+            $mform->addRule('grade', get_string('required'), 'required', null, 'client');
             $mform->addRule(
                 'grade',
                 get_string('err_valueoutofrange', 'mod_coursework'),

--- a/templates/submissions/tr/marking.mustache
+++ b/templates/submissions/tr/marking.mustache
@@ -157,7 +157,7 @@
                     </span>
                 {{/released}}
 
-                <a href="{{{url}}}" class="font-weight-bold pl-1" data-mark-action="editfeedback" data-mark="{{markvalue}}">{{markvalue}}</a>
+                <a href="{{{url}}}" class="font-weight-bold pl-1" data-mark-action="editfeedback" data-mark="{{markvalue}}">{{#markvalue}}{{markvalue}}{{/markvalue}}{{^markvalue}}-{{/markvalue}}</a>
             {{/mark}}
 
             {{#addfinalfeedback}}

--- a/templates/submissions/tr/marking.mustache
+++ b/templates/submissions/tr/marking.mustache
@@ -157,7 +157,7 @@
                     </span>
                 {{/released}}
 
-                <a href="{{{url}}}" class="font-weight-bold pl-1" data-mark-action="editfeedback" data-mark="{{markvalue}}">{{#markvalue}}{{markvalue}}{{/markvalue}}{{^markvalue}}-{{/markvalue}}</a>
+                <a href="{{{url}}}" class="font-weight-bold pl-1" data-mark-action="editfeedback" data-mark="{{markvalue}}">{{markvalue}}{{^markvalue}}-{{/markvalue}}</a>
             {{/mark}}
 
             {{#addfinalfeedback}}

--- a/tests/behat/feedback_files.feature
+++ b/tests/behat/feedback_files.feature
@@ -29,8 +29,9 @@ Feature: Adding feedback files
     And I click on the add feedback button
     And I upload "mod/coursework/tests/files_for_uploading/Test_image.png" file to "Upload a file" filemanager
     When I upload "mod/coursework/tests/files_for_uploading/Test_document_two.docx" file to "Upload a file" filemanager
+    And I set the field "Mark" to "52"
     And I press "Save and finalise"
-
+    And I should see "Changes saved"
     And I visit the coursework page
     And I publish the grades
     And I log out

--- a/tests/behat/feedback_final_feedback_double_marking.feature
+++ b/tests/behat/feedback_final_feedback_double_marking.feature
@@ -22,6 +22,7 @@ Feature: Adding and editing final feedback
     And I click the new multiple final feedback button for the student
     And I set the field "Mark" to "57"
     And I press "Save and finalise"
+    And I should see "Changes saved"
     Then I visit the coursework page
     And I should see the final agreed grade as 57
 
@@ -34,6 +35,7 @@ Feature: Adding and editing final feedback
     And I click the new multiple final feedback button for the student
     And I set the field "Mark" to "57"
     And I press "Save as draft"
+    And I should see "Changes saved"
     Then I visit the coursework page
     And I should see the final agreed grade as 57
     And I should see the final agreed grade status "Draft"
@@ -57,10 +59,10 @@ Feature: Adding and editing final feedback
     And I set the field "Mark" to "58"
     And I set the field "Comment" to "New comment"
     And I press "Save and finalise"
+    And I should see "Changes saved"
     Then I visit the coursework page
     When I click the edit final feedback button
     And I wait until the page is ready
-    And I wait "1" seconds
     And the field "Mark" matches value "58"
     And the grade comment textarea field matches "New comment"
 
@@ -72,6 +74,7 @@ Feature: Adding and editing final feedback
     When I click the new multiple final feedback button for the student
     And I set the field "Mark" to "59"
     And I press "Save and finalise"
+    And I should see "Changes saved"
 
   Scenario: Editing final feedback from others
     And managers do not have the manage capability
@@ -81,6 +84,31 @@ Feature: Adding and editing final feedback
     When I visit the coursework page
     When I click the edit final feedback button
     And I wait until the page is ready
-    And I wait "2" seconds
-    And I wait until the page is ready
     And the field "Mark" matches value "45"
+
+  @javascript
+  Scenario: Setting a new final feedback but leaving require grade field blank
+    Given there are feedbacks from both teachers
+    And I am logged in as a manager
+    And I visit the coursework page
+    And I click the new multiple final feedback button for the student
+    And I set the field "Mark" to ""
+    And I press "Save and finalise"
+    And I should see "Required" in the "#fitem_id_grade" "css_element"
+    And I should not see "Changes saved"
+
+  @javascript
+  Scenario: Updating the final feedback but leaving require grade field blank
+    Given there are feedbacks from both teachers
+    And I am logged in as a manager
+    And I visit the coursework page
+    And I click the new multiple final feedback button for the student
+    And I set the field "Mark" to "22"
+    And I press "Save and finalise"
+    And I should see "Changes saved"
+    And I visit the coursework page
+    And I click on "22" "link" in the "[data-behat-markstage='final_agreed']" "css_element"
+    And I set the field "Mark" to ""
+    And I press "Save and finalise"
+    And I should see "Required" in the "#fitem_id_grade" "css_element"
+    And I should not see "Changes saved"

--- a/tests/behat/feedback_multiple_assessor_feedback.feature
+++ b/tests/behat/feedback_multiple_assessor_feedback.feature
@@ -26,7 +26,7 @@ Feature: Multiple assessors simple grading form
     And I set the field "Mark" to "52"
     And I set the field "Comment" to "Some new comment 3"
     And I click on "Save and finalise" "button"
-    And I wait until "OK" "button" exists
+    And I should see "Changes saved"
     And I visit the edit feedback page
     And the field "Mark" matches value "52"
     And the field "Comment" matches value "Some new comment 3"
@@ -38,7 +38,9 @@ Feature: Multiple assessors simple grading form
     And I visit the coursework page
     And I click on "Add mark" "link"
     When I upload "mod/coursework/tests/files_for_uploading/Test_document.docx" file to "Upload a file" filemanager
+    And I set the field "Mark" to "52"
     And I press "Save and finalise"
+    And I should see "Changes saved"
     And I visit the coursework page
     And I click the edit feedback button
     Then I should see "1" elements in "Upload a file" filemanager
@@ -67,7 +69,9 @@ Feature: Multiple assessors simple grading form
     And I visit the coursework page
     And I click on "Add mark" "link"
     When I upload "mod/coursework/tests/files_for_uploading/Test_document.docx" file to "Upload a file" filemanager
+    And I set the field "Mark" to "52"
     And I press "Save and finalise"
+    And I should see "Changes saved"
     And I visit the coursework page
     And I click the edit feedback button
     And I upload "mod/coursework/tests/files_for_uploading/Test_document_two.docx" file to "Upload a file" filemanager
@@ -102,6 +106,7 @@ Feature: Multiple assessors simple grading form
     And I follow "Add mark"
     And I set the field "Mark" to "59"
     And I press "Save and finalise"
+    And I should see "Changes saved"
     And I visit the coursework page
     # Cannot see agree marking until specific capability awarded.
     Then I should not see "Agree marking"


### PR DESCRIPTION
- Make agreed grade a required field
- include test to cover it
- fix existing tests which used grade form but left grade field blank (e.g. when uploading feedback files)