### PR TITLE
Move extensions out of files loop

### DIFF
--- a/templates/submissions/tr/submissions.mustache
+++ b/templates/submissions/tr/submissions.mustache
@@ -32,47 +32,46 @@
                     {{/datemodified}}
                 </div>
             </div>
-
-            {{#extensiondeadline}}
+        {{/files}}
+        {{#extensiondeadline}}
             <div class="bg-light badge-pill my-2 py-1">
                 <div class="position-relative d-flex align-items-center">
-                        <div class="mr-3">
-                            <i class="fa-regular fa-clock"></i>
-                        </div>
-                        <div class="small">
-                            {{#str}} extension, mod_coursework {{/str}}
-                            <br>
-                            {{#userdate}}
-                                {{.}}, {{#str}} strftimedatetime, langconfig {{/str}}
-                            {{/userdate}}
-                        </div>
+                    <div class="mr-3">
+                        <i class="fa-regular fa-clock"></i>
+                    </div>
+                    <div class="small">
+                        {{#str}} extension, mod_coursework {{/str}}
+                        <br>
+                        {{#userdate}}
+                            {{.}}, {{#str}} strftimedatetime, langconfig {{/str}}
+                        {{/userdate}}
+                    </div>
                 </div>
             </div>
-            {{/extensiondeadline}}
+        {{/extensiondeadline}}
 
-            {{#submittedlate}}
-                <span class="badge badge-pill badge-warning">
+        {{#submittedlate}}
+            <span class="badge badge-pill badge-warning">
                     <i class="fa-regular fa-clock m-1"></i>
-                    {{#str}} submitted_late, mod_coursework {{/str}}
+                {{#str}} submitted_late, mod_coursework {{/str}}
                 </span>
-            {{/submittedlate}}
+        {{/submittedlate}}
 
-            {{#flaggedplagiarism}}
-                <span class="badge badge-pill badge-danger">
+        {{#flaggedplagiarism}}
+            <span class="badge badge-pill badge-danger">
                     <i class="fa-regular fa-flag m-1"></i>
-                    {{#str}} flagged_plagiarism, mod_coursework {{/str}}
+                {{#str}} flagged_plagiarism, mod_coursework {{/str}}
                 </span>
-            {{/flaggedplagiarism}}
+        {{/flaggedplagiarism}}
 
-            {{#plagiarismlinks}}
-                <div>
+        {{#plagiarismlinks}}
+            <div>
                     <span class="sr-only">
                         {{#str}} plagiarism_report, mod_coursework {{/str}}
                     </span>
-                    {{{plagiarismlinks}}}
-                </div>
-            {{/plagiarismlinks}}
-        {{/files}}
+                {{{plagiarismlinks}}}
+            </div>
+        {{/plagiarismlinks}}
     {{/submissiondata}}
 
     {{^submissiondata}}


### PR DESCRIPTION
- Where a submission has multiple files attached, do not repeat the extension info etc for each file
- Just moved all the code shown outside of {{#files}}{{/files}}
<img width="1052" height="260" alt="multiple-extension-info" src="https://github.com/user-attachments/assets/3780169a-7082-468e-aecf-53288e99b3ab" />
