### PR TITLE
CTP-5801 Fix: membership_count must be of type int

### DIFF
--- a/classes/traits/allocatable_functions.php
+++ b/classes/traits/allocatable_functions.php
@@ -105,8 +105,8 @@ trait allocatable_functions {
         if ($coursework->sampling_enabled()) {
             $expectedmarkers = assessment_set_membership::membership_count(
                 $coursework->id(),
-                $this->id(),
-                $this->type()
+                $this->type(),
+                $this->id()
             ) + 1;  // Add one as there is always a marker for stage 1.
         }
 

--- a/tests/phpunit/auto_grader/percentage_distance_test.php
+++ b/tests/phpunit/auto_grader/percentage_distance_test.php
@@ -74,6 +74,24 @@ final class percentage_distance_test extends \advanced_testcase {
         $this->assertEquals(0, $DB->count_records('coursework_feedbacks'));
     }
 
+    /**
+     * Test there is no error after student submission with:
+     *   - Number of times each submission should initially be marked: 2
+     *   - Sampling enabled: Yes
+     *   - Automatic agreement of marks: Percentage distance
+     */
+    public function test_no_error_with_auto_agreement_and_sampling(): void {
+        $coursework = $this->get_coursework();
+        $coursework->update_attribute('samplingenabled', 1);
+        $user = $this->get_student();
+        $this->create_a_submission_for_the_student();
+        $object = new percentage_distance($this->get_coursework(), $user, 10);
+
+        $object->create_auto_grade_if_rules_match($user);
+
+        $this->assertTrue(true); // Check there are no errors above.
+    }
+
     public function test_that_a_new_record_is_created_when_all_initial_feedbacks_are_close_enough(): void {
         global $DB;
 


### PR DESCRIPTION
Previously with:

  - Number of times each submission should initially be marked: 2
  - Sampling enabled: Yes
  - Automatic agreement of marks: Percentage distance.

when the student uploaded a submission they would get:

  Exception - mod_coursework\models\assessment_set_membership::
  membership_count(): Argument #3 ($allocatableid) must be of type int,
  string given, called in [dirroot]/mod/coursework/classes/traits/
  allocatable_functions.php on line 106