### PR TITLE
Ctp 5928 hide student name

### DIFF
--- a/classes/export/csv/cells/cell_base.php
+++ b/classes/export/csv/cells/cell_base.php
@@ -57,18 +57,6 @@ abstract class cell_base implements cell_interface {
     }
 
     /**
-     * Function to check if a user can see real names/usernames even if blind marking is enabled
-     * @return bool
-     * @throws coding_exception
-     */
-    public function can_view_hidden() {
-        return
-            !$this->coursework->blindmarking
-            ||
-            has_any_capability(['mod/coursework:viewanonymous', 'mod/coursework:canexportfinalgrades'], $this->coursework->get_context());
-    }
-
-    /**
      * Function to check if the student was given an extension
      * @param $student
      * @return bool

--- a/classes/export/csv/cells/email_cell.php
+++ b/classes/export/csv/cells/email_cell.php
@@ -37,7 +37,7 @@ class email_cell extends cell_base {
      */
     public function get_cell($submission, $student, $stageidentifier) {
 
-        if ($this->can_view_hidden() || $submission->is_published()) {
+        if (!$this->coursework->hide_student_identities()) {
             $name = $student->email;
         } else {
             $name = get_string('hidden', 'coursework');

--- a/classes/export/csv/cells/idnumber_cell.php
+++ b/classes/export/csv/cells/idnumber_cell.php
@@ -37,7 +37,7 @@ class idnumber_cell extends cell_base {
      */
     public function get_cell($submission, $student, $stageidentifier) {
 
-        if ($this->can_view_hidden() || $submission->is_published()) {
+        if (!$this->coursework->hide_student_identities()) {
             $name = $student->idnumber;
         } else {
             $name = get_string('hidden', 'coursework');

--- a/classes/export/csv/cells/name_cell.php
+++ b/classes/export/csv/cells/name_cell.php
@@ -37,7 +37,7 @@ class name_cell extends cell_base {
      */
     public function get_cell($submission, $student, $stageidentifier) {
 
-        if ($this->can_view_hidden() || $submission->is_published()) {
+        if (!$this->coursework->hide_student_identities()) {
             return $student->lastname . ' ' . $student->firstname;
         } else if (get_config('mod_coursework', 'use_candidate_numbers_for_hidden_name')) {
             return $this->get_candidate_number($student->id) ?? get_string('hidden');

--- a/classes/export/csv/cells/username_cell.php
+++ b/classes/export/csv/cells/username_cell.php
@@ -37,7 +37,7 @@ class username_cell extends cell_base {
      */
     public function get_cell($submission, $student, $stageidentifier) {
 
-        if ($this->can_view_hidden() || $submission->is_published()) {
+        if (!$this->coursework->hide_student_identities()) {
             $username = $student->username;
         } else {
             $username = get_string('hidden', 'coursework');

--- a/classes/grading_table_row_base.php
+++ b/classes/grading_table_row_base.php
@@ -120,21 +120,6 @@ class grading_table_row_base implements user_row {
     }
 
     /**
-     * Can the current user see the row user's name?
-     * @return bool
-     * @throws coding_exception
-     */
-    public function can_see_user_name(): bool {
-        if (!$this->get_coursework()->blindmarking || $this->is_published()) {
-            return true;
-        }
-        return has_capability(
-            'mod/coursework:viewanonymous',
-            $this->get_coursework()->get_context()
-        );
-    }
-
-    /**
      * Avoid calling repeatedly as it results in DB queries.
      * Will return the username if permissions allow, otherwise, an anonymous placeholder. Can't delegate to the similar
      * submission::get_user_name() function as there may not be a submission.
@@ -146,11 +131,8 @@ class grading_table_row_base implements user_row {
      * @throws coding_exception
      */
     public function get_user_name($link = false) {
-
         global $DB;
-
-        $viewanonymous = has_capability('mod/coursework:viewanonymous', $this->get_coursework()->get_context());
-        if (!$this->get_coursework()->blindmarking || $viewanonymous || $this->is_published()) {
+        if (!$this->get_coursework()->hide_student_identities()) {
             $user = $DB->get_record('user', ['id' => $this->get_allocatable_id()]);
             $fullname = fullname($user);
             $allowed = has_capability('moodle/user:viewdetails', $this->get_coursework()->get_context());
@@ -175,9 +157,7 @@ class grading_table_row_base implements user_row {
      */
     public function get_idnumber() {
         global $DB;
-
-        $viewanonymous = has_capability('mod/coursework:viewanonymous', $this->get_coursework()->get_context());
-        if (!$this->get_coursework()->blindmarking || $viewanonymous || $this->is_published()) {
+        if (!$this->get_coursework()->hide_student_identities()) {
             $user = $DB->get_record('user', ['id' => $this->get_allocatable_id()]);
             return $user->idnumber;
         } else {
@@ -194,9 +174,7 @@ class grading_table_row_base implements user_row {
      */
     public function get_email() {
         global $DB;
-
-        $viewanonymous = has_capability('mod/coursework:viewanonymous', $this->get_coursework()->get_context());
-        if (!$this->get_coursework()->blindmarking || $viewanonymous || $this->is_published()) {
+        if (!$this->get_coursework()->hide_student_identities()) {
             $user = $DB->get_record('user', ['id' => $this->get_allocatable_id()]);
             return $user->email;
         } else {
@@ -337,22 +315,6 @@ class grading_table_row_base implements user_row {
     public function has_submission() {
         $submission = $this->get_submission();
         return !empty($submission);
-    }
-
-    /**
-     * Checks to see whether we should show the current user who this student is.
-     */
-    public function can_view_username() {
-
-        if (has_capability('mod/coursework:viewanonymous', $this->get_coursework()->get_context())) {
-            return true;
-        }
-
-        if ($this->get_coursework()->blindmarking) {
-            return false;
-        }
-
-        return true;
     }
 
     /**

--- a/classes/models/coursework.php
+++ b/classes/models/coursework.php
@@ -924,7 +924,7 @@ class coursework extends table_base {
 
                 $foldername = '';
 
-                if ($this->blindmarking == 0 || has_capability('mod/coursework:viewanonymous', $this->get_context())) {
+                if (!$this->hide_student_identities()) {
                     $submissionuser = $submission->get_allocatable();
                     if ($this->is_configured_to_have_group_submissions() && $submissionuser->name) {
                         $foldername = $submissionuser->name . '_';
@@ -1590,6 +1590,19 @@ class coursework extends table_base {
      */
     public function blindmarking_enabled() {
         return (bool)$this->blindmarking;
+    }
+
+    /**
+     * Should student identities be hidden?
+     * @return bool
+     * @throws coding_exception
+     */
+    public function hide_student_identities(): bool {
+        return $this->blindmarking_enabled()
+        && !has_any_capability(
+            ['mod/coursework:viewanonymous', 'mod/coursework:canexportfinalgrades'],
+            $this->get_context()
+        );
     }
 
     /**

--- a/classes/models/submission.php
+++ b/classes/models/submission.php
@@ -745,8 +745,7 @@ class submission extends table_base implements renderable {
      */
     public function get_allocatable_name($aslink = false) {
 
-        $viewanonymous = has_capability('mod/coursework:viewanonymous', $this->get_coursework()->get_context());
-        if (!$this->get_coursework()->blindmarking || $viewanonymous || $this->is_published() || $this->get_coursework()->is_configured_to_have_group_submissions()) {
+        if (!$this->get_coursework()->hide_student_identities() || $this->get_coursework()->is_configured_to_have_group_submissions()) {
             $fullname = $this->get_allocatable()->name();
 
             $allowed = has_capability('moodle/user:viewdetails', $this->get_context());

--- a/classes/personaldeadline/table/row/builder.php
+++ b/classes/personaldeadline/table/row/builder.php
@@ -79,15 +79,6 @@ class builder implements user_row {
     }
 
     /**
-     * Assume that if someone can see the coursework personal deadline table then they can see the full user names.
-     *
-     * @return bool
-     */
-    public function can_view_username() {
-        return true;
-    }
-
-    /**
      * @return allocatable_cell
      */
     public function get_allocatable_cell() {

--- a/classes/render_helpers/grading_report/cells/group_cell.php
+++ b/classes/render_helpers/grading_report/cells/group_cell.php
@@ -47,7 +47,7 @@ class group_cell extends cell_base implements allocatable_cell {
         $content .= '<div class="group_style">';
         $content .= '<select>';
 
-        if ($this->coursework->blindmarking_enabled() && !has_capability('mod/coursework:viewanonymous', $this->coursework->get_context()) && !$rowobject->is_published()) {
+        if ($this->coursework->hide_student_identities()) {
             $content .= '<option class="expand_members" selected="selected">' . get_string('membershidden', 'coursework') . '</option>';
         } else {
             $content .= '<option class="expand_members" selected="selected">' . get_string('viewmembers', 'coursework') . '</option>';
@@ -99,7 +99,7 @@ class group_cell extends cell_base implements allocatable_cell {
      */
     protected function add_group_member_name($groupmember, $rowobject) {
         $text = '<option>';
-        if ($this->coursework->blindmarking_enabled() && !has_capability('mod/coursework:viewanonymous', $this->coursework->get_context()) && !$rowobject->is_published()) {
+        if ($this->coursework->hide_student_identities()) {
             $text .= 'Hidden';
         } else {
             $text .= $groupmember->profile_link() . ' (' . $groupmember->email . ')';

--- a/classes/render_helpers/grading_report/cells/user_cell.php
+++ b/classes/render_helpers/grading_report/cells/user_cell.php
@@ -44,15 +44,12 @@ class user_cell extends cell_base implements allocatable_cell {
      * @throws \coding_exception
      */
     public function get_table_header($options = []) {
-
-        $viewanonymous = has_capability('mod/coursework:viewanonymous', $this->coursework->get_context());
-
         // Adding this line so that the sortable heading function will make a sortable link unique to the table
         // If tablename is set
         $tablename = (!empty($options['tablename'])) ? $options['tablename'] : '';
 
         // allow to sort users only if CW is not set to blind marking or a user has capability to view anonymous
-        if ($viewanonymous || !$this->coursework->blindmarking) {
+        if (!$this->coursework->hide_student_identities()) {
             $sortbyfirstname = $this->helper_sortable_heading(
                 get_string('firstname'),
                 'firstname',

--- a/classes/render_helpers/grading_report/data/actions_cell_data.php
+++ b/classes/render_helpers/grading_report/data/actions_cell_data.php
@@ -48,11 +48,7 @@ class actions_cell_data extends cell_data_base {
      */
     public function get_table_cell_data(grading_table_row_base $rowsbase): ?stdClass {
         $data = new stdClass();
-
-        $identitieshidden = $this->coursework->blindmarking_enabled() &&
-            !has_capability('mod/coursework:viewanonymous', $this->coursework->get_context());
-
-        if (!$identitieshidden) {
+        if (!$this->coursework->hide_student_identities()) {
             $this->set_extension_data($data, $rowsbase);
             $this->set_personaldeadline_data($data, $rowsbase);
         }
@@ -179,7 +175,7 @@ class actions_cell_data extends cell_data_base {
             $data->finalise = new stdClass();
             $data->finalise->url = router::instance()
                 ->get_path('finalise submission', ['submission' => $rowsbase->get_submission()], false, false);
-            $data->finalise->studentname = $rowsbase->can_see_user_name()
+            $data->finalise->studentname = !$rowsbase->get_coursework()->hide_student_identities()
                 ? $rowsbase->get_allocatable()->name() : get_string('hidden', 'mod_coursework');
         }
     }
@@ -206,7 +202,7 @@ class actions_cell_data extends cell_data_base {
             );
             $data->unfinalise = new stdClass();
             $data->unfinalise->url = $url->out(false);
-            $data->unfinalise->studentname = $rowsbase->can_see_user_name()
+            $data->unfinalise->studentname = !$rowsbase->get_coursework()->hide_student_identities()
                 ? $rowsbase->get_allocatable()->name() : get_string('hidden', 'mod_coursework');
         }
     }

--- a/classes/render_helpers/grading_report/data/student_cell_data.php
+++ b/classes/render_helpers/grading_report/data/student_cell_data.php
@@ -48,7 +48,7 @@ class student_cell_data extends cell_data_base {
     public function get_table_cell_data(grading_table_row_base $rowsbase): ?stdClass {
         $submissiontype = new stdClass();
         $allocatable = $rowsbase->get_allocatable();
-        $hidden = $this->should_hide_identity();
+        $hidden = $rowsbase->get_coursework()->hide_student_identities();
 
         if ($allocatable instanceof group) {
             $submissiontype->group = $this->get_group_data($allocatable, $hidden);
@@ -122,7 +122,7 @@ class student_cell_data extends cell_data_base {
             'id' => $rowsbase->get_allocatable_id(),
             'name' => $this->get_enhanced_name_with_candidate_number(
                 $user->id(),
-                $rowsbase->can_see_user_name()
+                !$rowsbase->get_coursework()->hide_student_identities()
                     ? $rowsbase->get_allocatable()->name()
                     : get_string('hidden', 'mod_coursework')
             ),
@@ -146,17 +146,6 @@ class student_cell_data extends cell_data_base {
 
         $candidatenumber = $this->get_candidate_number($userid);
         return $candidatenumber ?: get_string($fallbackstring, 'mod_coursework');
-    }
-
-    /**
-     * Determine if the identity should be hidden.
-     *
-     * @return bool
-     * @throws coding_exception
-     */
-    private function should_hide_identity() {
-        return $this->coursework->blindmarking_enabled() &&
-            !has_capability('mod/coursework:viewanonymous', $this->coursework->get_context());
     }
 
     /**

--- a/classes/renderers/grading_report_renderer.php
+++ b/classes/renderers/grading_report_renderer.php
@@ -55,7 +55,6 @@ class grading_report_renderer extends plugin_renderer_base {
     public function get_grading_report_data(coursework $coursework): \stdClass {
 
         $tablerows = grading_report::get_table_rows_for_page($coursework);
-        $blindmarking = $coursework->blindmarking_enabled() && !has_capability('mod/coursework:viewanonymous', $coursework->get_context());
         $participantcontextids = user::get_user_picture_context_ids(
             $coursework->get_course_id()
         );
@@ -65,7 +64,7 @@ class grading_report_renderer extends plugin_renderer_base {
 
         $template = new stdClass();
         $template->coursework = self::prepare_coursework_data($coursework);
-        $template->blindmarkingenabled = $blindmarking;
+        $template->blindmarkingenabled = $coursework->hide_student_identities();
         $template->tiienabled = $coursework->tii_enabled();
 
         $currenturl = new moodle_url('/mod/coursework/view.php', ['id' => $coursework->get_course_module()->id]);
@@ -93,7 +92,7 @@ class grading_report_renderer extends plugin_renderer_base {
 
             // If this row represents a user (not a group), add the user picture.
             $allocatable = $rowobject->get_allocatable();
-            if ($allocatable->type() === 'user' && !$blindmarking) {
+            if ($allocatable->type() === 'user' && !$template->blindmarkingenabled) {
                 $participantcontextid = $participantcontextids[$allocatable->id()] ?? null;
                 $trdata->submissiontype->user->picture =
                     user::get_picture_url_from_context_id($participantcontextid, $allocatable->picture);
@@ -243,7 +242,7 @@ class grading_report_renderer extends plugin_renderer_base {
         $data->coursework = self::prepare_coursework_data($coursework);
         $data->tiienabled = $coursework->tii_enabled();
 
-        if ($allocatabletype === "user" && (!$coursework->blindmarking_enabled() || has_capability('mod/coursework:viewanonymous', $coursework->get_context()))) {
+        if ($allocatabletype === "user" && !$coursework->hide_student_identities()) {
             $data->submissiontype->user->picture = user::get_picture_url_from_context_id(
                 context_user::instance($allocatableid)->id,
                 $allocatable->picture

--- a/classes/user_row.php
+++ b/classes/user_row.php
@@ -38,8 +38,6 @@ interface user_row {
 
     public function get_email();
 
-    public function can_view_username();
-
     /**
      * @return allocatable
      */


### PR DESCRIPTION
- Introduces a new method coursework::hide_student_identities() to replace the variety of other ways of calculating this in the plugin
- Deliberately omits the previous requirement for names to be visible if the submission is published (CTP-5062)