### PR TITLE
CTP-5768 use get_from_id()

### DIFF
--- a/actions/allocate.php
+++ b/actions/allocate.php
@@ -221,11 +221,10 @@ function coursework_render_page(coursework $coursework) {
 $coursemoduleid = required_param('id', PARAM_INT);
 $coursemodule = get_coursemodule_from_id('coursework', $coursemoduleid, 0, false, MUST_EXIST);
 $course = $DB->get_record('course', ['id' => $coursemodule->course], '*', MUST_EXIST);
-$coursework = $DB->get_record('coursework', ['id' => $coursemodule->instance], '*', MUST_EXIST);
 $formsavebutton = optional_param('save', 0, PARAM_BOOL);
 $samplingformsavebutton = optional_param('save_sampling', 0, PARAM_BOOL);
 $allocateallbutton = optional_param('auto-allocate-all', 0, PARAM_BOOL);
-$coursework = coursework::find($coursework);
+$coursework = coursework::get_from_id($coursemodule->instance, MUST_EXIST);
 
 require_login($course, true, $coursemodule);
 

--- a/actions/deadline_extensions/update.php
+++ b/actions/deadline_extensions/update.php
@@ -42,7 +42,7 @@ require_login($controller->get_course(), false, $controller->get_coursemodule())
 if (!$delete) {
     $controller->update_deadline_extension();
 } else {
-    $deadlineextension = mod_coursework\models\deadline_extension::find($extensionid);
+    $deadlineextension = mod_coursework\models\deadline_extension::get_from_id($extensionid);
     $redirecturl = new moodle_url('/mod/coursework/actions/deadline_extensions/edit.php', ['id' => $extensionid]);
     if (!$deadlineextension || !$deadlineextension->courseworkid) {
         redirect(

--- a/actions/general_feedback.php
+++ b/actions/general_feedback.php
@@ -33,8 +33,7 @@ $cm = get_coursemodule_from_id('coursework', $cmid, 0, false, MUST_EXIST);
 $course = $DB->get_record('course', ['id' => $cm->course]);
 require_login($course, false, $cm);
 
-$courseworkrecord = $DB->get_record('coursework', ['id' => $cm->instance], '*', MUST_EXIST);
-$coursework = coursework::find($courseworkrecord, false);
+$coursework = coursework::get_from_id($cm->instance, MUST_EXIST);
 
 if (!has_capability('mod/coursework:addinitialgrade', $PAGE->context)) {
     throw new moodle_exception('access_denied', 'coursework');

--- a/actions/processallocation.php
+++ b/actions/processallocation.php
@@ -38,8 +38,7 @@ require_once($CFG->dirroot . '/mod/coursework/lib.php');
 $coursemoduleid = required_param('coursemoduleid', PARAM_INT);
 $coursemodule = get_coursemodule_from_id('coursework', $coursemoduleid, 0, false, MUST_EXIST);
 $course = $DB->get_record('course', ['id' => $coursemodule->course], '*', MUST_EXIST);
-$coursework = $DB->get_record('coursework', ['id' => $coursemodule->instance], '*', MUST_EXIST);
-$coursework = coursework::find($coursework);
+$coursework = coursework::get_from_id($coursemodule->instance, MUST_EXIST);
 $assessorallocationstrategy = optional_param('assessorallocationstrategy', false, PARAM_TEXT);
 
 require_login($course, true, $coursemodule);

--- a/actions/releasemarks.php
+++ b/actions/releasemarks.php
@@ -36,7 +36,7 @@ if (!$cm) {
     redirect($returnurl, get_string('course_module_not_found', 'mod_coursework'));
 }
 
-$coursework = coursework::find($cm->instance);
+$coursework = coursework::get_from_id($cm->instance);
 if (!$coursework) {
     redirect($returnurl, get_string('coursework_not_found', 'mod_coursework'));
 }

--- a/actions/revert.php
+++ b/actions/revert.php
@@ -35,10 +35,9 @@ $cmid = required_param('cmid', PARAM_INT);
 $submissionid = required_param('submissionid', PARAM_INT);
 
 $cm = $DB->get_record('course_modules', ['id' => $cmid]);
-$coursework = coursework::find($cm->instance);
+$coursework = coursework::get_from_id($cm->instance);
 $course = $DB->get_record('course', ['id' => $cm->course]);
-$submissiondb = $DB->get_record('coursework_submissions', ['id' => $submissionid]);
-$submission = submission::find($submissiondb);
+$submission = submission::get_from_id($submissionid);
 
 require_login($course, false, $cm);
 $url = new moodle_url('/mod/coursework/view.php', ['id' => $cm->id]);

--- a/actions/set_personaldeadlines.php
+++ b/actions/set_personaldeadlines.php
@@ -33,8 +33,7 @@ require_once($CFG->dirroot . '/mod/coursework/lib.php');
 $coursemoduleid = required_param('id', PARAM_INT);
 $coursemodule = get_coursemodule_from_id('coursework', $coursemoduleid, 0, false, MUST_EXIST);
 $course = $DB->get_record('course', ['id' => $coursemodule->course], '*', MUST_EXIST);
-$coursework = $DB->get_record('coursework', ['id' => $coursemodule->instance], '*', MUST_EXIST);
-$coursework = coursework::find($coursework);
+$coursework = coursework::get_from_id($coursemodule->instance);
 
 // SQL sort for allocation table.
 $sortby = optional_param('sortby', '', PARAM_ALPHA);

--- a/actions/submitonbehalfofstudent.php
+++ b/actions/submitonbehalfofstudent.php
@@ -33,10 +33,10 @@ global $CFG, $DB, $PAGE, $OUTPUT;
 
 $coursemoduleid = required_param('cmid', PARAM_INT);
 $coursemodule = $DB->get_record('course_modules', ['id' => $coursemoduleid]);
-$coursework = coursework::find($coursemodule->instance);
+$coursework = coursework::get_from_id($coursemodule->instance);
 $course = $DB->get_record('course', ['id' => $coursemodule->course]);
 $studentid = optional_param('userid', 0, PARAM_INT);
-$student = user::find($studentid);
+$student = user::get_from_id($studentid);
 
 // Get an empty submission for the form even if we know there won't be one.
 $submission = $coursework->get_user_submission($student);

--- a/actions/upload_allocations.php
+++ b/actions/upload_allocations.php
@@ -34,7 +34,7 @@ require_once($CFG->libdir . '/csvlib.class.php');
 $coursemoduleid = required_param('cmid', PARAM_INT);
 
 $coursemodule = $DB->get_record('course_modules', ['id' => $coursemoduleid]);
-$coursework = coursework::find($coursemodule->instance);
+$coursework = coursework::get_from_id($coursemodule->instance);
 $course = $DB->get_record('course', ['id' => $coursemodule->course]);
 require_login($course, false, $coursemodule);
 

--- a/actions/upload_feedback.php
+++ b/actions/upload_feedback.php
@@ -33,7 +33,7 @@ $PAGE->set_url(new moodle_url('/mod/coursework/actions/upload_feedback.php'));
 $coursemoduleid = required_param('cmid', PARAM_INT);
 
 $coursemodule = $DB->get_record('course_modules', ['id' => $coursemoduleid]);
-$coursework = coursework::find($coursemodule->instance);
+$coursework = coursework::get_from_id($coursemodule->instance);
 $course = $DB->get_record('course', ['id' => $coursemodule->course]);
 
 require_login($course, false, $coursemodule);

--- a/actions/upload_grading_sheet.php
+++ b/actions/upload_grading_sheet.php
@@ -35,7 +35,7 @@ require_once($CFG->libdir . '/csvlib.class.php');
 $coursemoduleid = required_param('cmid', PARAM_INT);
 
 $coursemodule = $DB->get_record('course_modules', ['id' => $coursemoduleid]);
-$coursework = coursework::find($coursemodule->instance);
+$coursework = coursework::get_from_id($coursemodule->instance);
 $course = $DB->get_record('course', ['id' => $coursemodule->course]);
 
 require_login($course, false, $coursemodule);

--- a/actions/uploadannotatedsubmissionajax.php
+++ b/actions/uploadannotatedsubmissionajax.php
@@ -46,13 +46,13 @@ $submissionid = required_param('submissionid', PARAM_INT);
 $fileid = required_param('fileid', PARAM_INT);
 $filename = required_param('filename', PARAM_TEXT);
 
-$submission = submission::find($submissionid);
+$submission = submission::get_from_id($submissionid);
 
 if (!$submission) {
     return false;
 }
 
-$coursework = coursework::find($submission->get_coursework());
+$coursework = $submission->get_coursework();
 $context = $coursework->get_context();
 require_login($coursework->get_course(), false, $coursework->get_course_module());
 

--- a/backup/moodle2/restore_coursework_stepslib.php
+++ b/backup/moodle2/restore_coursework_stepslib.php
@@ -526,7 +526,7 @@ class restore_coursework_activity_structure_step extends restore_activity_struct
                     ['id' => $itemid]
                 );
 
-                $submission = submission::find($entry->id);
+                $submission = submission::get_from_id($entry->id);
                 $submission->rename_files(); // use cw function to handle file renaming as submission may have few files
             }
         }

--- a/classes/allocation/strategy/base.php
+++ b/classes/allocation/strategy/base.php
@@ -195,7 +195,7 @@ abstract class base {
         // get the allocations count value that's lowest (may represent multiple teachers), then get the first array
         // key (teacher id) that has that number of allocations.
         $smallestcount = min($teachercounts);
-        return user::find(array_search($smallestcount, $teachercounts));
+        return user::get_from_id(array_search($smallestcount, $teachercounts));
     }
 
     /**

--- a/classes/allocation/upload.php
+++ b/classes/allocation/upload.php
@@ -118,12 +118,12 @@ class upload {
                     if ($allocatabletype == 'user') {
                         // get user id
                         $suballocatable = $DB->get_record('user', [$assessoridentifier => $value]);
-                        $allocatable = ($suballocatable) ? user::find($suballocatable->id) : '';
+                        $allocatable = ($suballocatable) ? user::get_from_id($suballocatable->id) : '';
                     } else {
                         // get group id
                         $suballocatable = $DB->get_record('groups', ['courseid' => $this->coursework->course,
                                                                         'name' => $value]);
-                        $allocatable = ($suballocatable) ? group::find($suballocatable->id) : '';
+                        $allocatable = ($suballocatable) ? group::get_from_id($suballocatable->id) : '';
                     }
 
                     // check if allocatable exists in this coursework
@@ -251,12 +251,12 @@ class upload {
                     if ($allocatabletype == 'user') {
                         // get user id
                         $suballocatable = $DB->get_record('user', [$assessoridentifier => $value]);
-                        $allocatable = ($suballocatable) ? user::find($suballocatable->id) : '';
+                        $allocatable = ($suballocatable) ? user::get_from_id($suballocatable->id) : '';
                     } else {
                         // get group id
                         $suballocatable = $DB->get_record('groups', ['courseid' => $this->coursework->course,
                             'name' => $value]);
-                        $allocatable = ($suballocatable) ? group::find($suballocatable->id) : '';
+                        $allocatable = ($suballocatable) ? group::get_from_id($suballocatable->id) : '';
                     }
                 }
                 if ($allocatable && str_starts_with($cells[$keynum], 'assessor') && !empty($value)) {
@@ -322,7 +322,7 @@ class upload {
      * @return void
      */
     public function update_allocation($allocationid, $assessorid): void {
-        $allocation = allocation::find($allocationid);
+        $allocation = allocation::get_from_id($allocationid);
         $allocation->ismanual = 1;
         $allocation->assessorid = $assessorid;
         $allocation->save();

--- a/classes/controllers/controller_base.php
+++ b/classes/controllers/controller_base.php
@@ -103,15 +103,14 @@ abstract class controller_base {
         if (!empty($this->params['id'])) {
             $modelclass = $this->model_class();
             $modelname = $this->model_name();
-            $this->$modelname = $modelclass::find($this->params['id']);
+            $this->$modelname = $modelclass::get_from_id($this->params['id']);
             if (!$this->$modelname) {
                 throw new invalid_parameter_exception("Cannot find $modelclass ID " . $this->params['id']);
             }
             $this->coursework = $this->$modelname->get_coursework();
         }
         if (!empty($this->params['courseworkid'])) {
-            $coursework = $DB->get_record('coursework', ['id' => $this->params['courseworkid']], '*', MUST_EXIST);
-            $this->coursework = coursework::find($coursework);
+            $this->coursework = coursework::get_from_id($this->params['courseworkid']);
 
             $this->coursemodule = get_coursemodule_from_instance('coursework', $this->coursework->id);
 
@@ -122,7 +121,7 @@ abstract class controller_base {
         if (empty($this->coursemodule) && !empty($this->params['cmid'])) {
             $this->coursemodule = get_coursemodule_from_id('coursework', $this->params['cmid'], 0, false, MUST_EXIST);
             if (empty($this->coursework)) {
-                $this->coursework = coursework::find($this->coursemodule->instance);
+                $this->coursework = coursework::get_from_id($this->coursemodule->instance);
             }
             $this->params['courseid'] = $this->coursemodule->course;
         }

--- a/classes/controllers/deadline_extensions_controller.php
+++ b/classes/controllers/deadline_extensions_controller.php
@@ -95,11 +95,11 @@ class deadline_extensions_controller extends controller_base {
 
         $createurl = $this->get_router()->get_path('create deadline extension');
         $courseworkid = required_param('courseworkid', PARAM_INT);
-        $this->coursework = coursework::find($courseworkid) ?? null;
+        $this->coursework = coursework::get_from_id($courseworkid) ?? null;
         $allocatabletype = required_param('allocatabletype', PARAM_ALPHANUMEXT);
         $allocatableid = required_param('allocatableid', PARAM_INT);
         $classname = "\\mod_coursework\\models\\$allocatabletype";
-        $allocatable = $classname::find($allocatableid);
+        $allocatable = $classname::get_from_id($allocatableid);
         $this->form = new deadline_extension_form(
             $createurl,
             [
@@ -160,16 +160,12 @@ class deadline_extensions_controller extends controller_base {
      */
     public function edit_deadline_extension() {
         global $USER, $PAGE;
-
-        $params = [
-            'id' => $this->params['id'],
-        ];
-        $this->deadlineextension = deadline_extension::find($params);
+        $this->deadlineextension = deadline_extension::get_from_id($this->params['id']);
 
         $ability = new ability($USER->id, $this->coursework);
         $ability->require_can('edit', $this->deadlineextension);
 
-        $PAGE->set_url('/mod/coursework/actions/deadline_extensions/edit.php', $params);
+        $PAGE->set_url('/mod/coursework/actions/deadline_extensions/edit.php', ['id' => $this->params['id']]);
         $updateurl = $this->get_router()->get_path('update deadline extension');
 
         $formdata = ['courseworkid' => $this->coursework->id, 'extensionid' => $this->params['extensionid']];
@@ -194,7 +190,7 @@ class deadline_extensions_controller extends controller_base {
         global $USER;
         $extensionid = $this->params['extensionid'];
         $ability = new ability($USER->id, $this->coursework);
-        $deadlineextension = deadline_extension::find(['id' => $extensionid]);
+        $deadlineextension = deadline_extension::get_from_id($extensionid);
         if ($deadlineextension && $deadlineextension->can_be_deleted()) {
             $ability->require_can('edit', $deadlineextension);
             $deadlineextension->delete();
@@ -232,7 +228,7 @@ class deadline_extensions_controller extends controller_base {
         }
         $ability = new ability($USER->id, $this->coursework);
         $values = $this->form->get_data();
-        $this->deadlineextension = deadline_extension::find(['id' => $this->params['id']]);
+        $this->deadlineextension = deadline_extension::get_from_id($this->params['id']);
 
         $ability->require_can('update', $this->deadlineextension);
 

--- a/classes/controllers/feedback_controller.php
+++ b/classes/controllers/feedback_controller.php
@@ -117,7 +117,7 @@ class feedback_controller extends controller_base {
         $PAGE->set_url('/mod/coursework/actions/feedbacks/viewpdf.php', $urlparams);
 
         $ability = new ability($USER->id, $this->coursework);
-        $submission = submission::find($this->params['submissionid']);
+        $submission = submission::get_from_id($this->params['submissionid']);
 
         if ($ability->cannot('show', $submission)) {
             return false;
@@ -265,7 +265,7 @@ class feedback_controller extends controller_base {
         $teacherfeedback->lasteditedbyuser = $USER->id;
         $teacherfeedback->finalised = $this->params['finalised'] ? 1 : 0;
 
-        $submission = submission::find($this->params['submissionid']);
+        $submission = submission::get_from_id($this->params['submissionid']);
         $pathparams = [
             'submission' => $submission,
             'assessor' => core_user::get_user($this->params['assessorid']),

--- a/classes/controllers/moderations_controller.php
+++ b/classes/controllers/moderations_controller.php
@@ -165,7 +165,7 @@ class moderations_controller extends controller_base {
         $moderatoragreement->lasteditedby = $USER->id;
         $moderatoragreement->feedbackid = $this->params['feedbackid'];
 
-        $submission = submission::find($this->params['submissionid']);
+        $submission = submission::get_from_id($this->params['submissionid']);
         $pathparams = [
             'submission' => $submission,
             'moderator' => core_user::get_user($this->params['moderatorid']),

--- a/classes/controllers/personaldeadlines_controller.php
+++ b/classes/controllers/personaldeadlines_controller.php
@@ -194,7 +194,7 @@ class personaldeadlines_controller extends controller_base {
      */
     public function get_allocatable() {
         $allocatableclass = "\\mod_coursework\\models\\{$this->params['allocatabletype']}";
-        return $allocatableclass::find($this->params['allocatableid']);
+        return $allocatableclass::get_from_id($this->params['allocatableid']);
     }
 
     /**

--- a/classes/controllers/plagiarism_flagging_controller.php
+++ b/classes/controllers/plagiarism_flagging_controller.php
@@ -145,7 +145,7 @@ class plagiarism_flagging_controller extends controller_base {
         $plagiarismflag->submissionid = $this->params['submissionid'];
         $plagiarismflag->createdby = $USER->id;
 
-        $submission = submission::find($this->params['submissionid']);
+        $submission = submission::get_from_id($this->params['submissionid']);
         $pathparams = ['submission' => $submission];
         $url = $this->get_router()->get_path('new plagiarism flag', $pathparams, true);
         $PAGE->set_url($url);

--- a/classes/controllers/submissions_controller.php
+++ b/classes/controllers/submissions_controller.php
@@ -48,7 +48,7 @@ class submissions_controller extends controller_base {
 
     public function __construct($params = []) {
         if (!empty($params['submissionid'])) {
-            $this->submission = submission::find($params['submissionid']);
+            $this->submission = submission::get_from_id($params['submissionid']);
             $this->coursework = $this->submission->get_coursework();
         }
         if (

--- a/classes/controllers/submissions_controller.php
+++ b/classes/controllers/submissions_controller.php
@@ -240,11 +240,7 @@ class submissions_controller extends controller_base {
                 if (!empty($useridcommaseparatedlist)) {
                     $userids = explode(',', $useridcommaseparatedlist);
                     foreach ($userids as $u) {
-                        $notifyuser = $DB->get_record('user', ['id' => trim($u)]);
-
-                        if (!empty($notifyuser)) {
-                            $mailer->send_submission_notification($notifyuser);
-                        }
+                        $mailer->send_submission_notification(trim($u));
                     }
                 }
             }
@@ -366,7 +362,7 @@ class submissions_controller extends controller_base {
                 ['courseworkid' => $this->coursework->id(), 'allocatableid' => $aid, 'allocatabletype' => $this->params['allocatabletype']]
             );
             if (!empty($submissiondb)) {
-                $submission = submission::find($submissiondb);
+                $submission = submission::get_from_id($submissiondb->id);
 
                 if ($submission->can_be_unfinalised()) {
                     $submission->finalisedstatus = submission::FINALISED_STATUS_MANUALLY_UNFINALISED;

--- a/classes/cron.php
+++ b/classes/cron.php
@@ -88,7 +88,7 @@ class cron {
             /**
              * @var coursework $coursework
              */
-            $coursework = coursework::find($rawcoursework);
+            $coursework = coursework::get_from_id($rawcoursework->id);
             if (!$coursework || !$coursework->is_coursework_visible()) {// check if coursework exists and is not hidden
                 continue;
             }
@@ -209,7 +209,7 @@ class cron {
         $usercounter = [];
 
         foreach ($users as $user) {
-            $courseworkinstance = coursework::find($user->courseworkid);
+            $courseworkinstance = coursework::get_from_id($user->courseworkid);
 
             $mailer = new mailer($courseworkinstance);
 
@@ -315,7 +315,7 @@ class cron {
 
         $graders = get_enrolled_users($context, 'mod/coursework:addinitialgrade');
         foreach ($graders as $grader) {
-            $result[$grader->id] = user::find($grader, false);
+            $result[$grader->id] = user::get_from_id($grader->id);
         }
         $managers = get_enrolled_users($context, 'mod/coursework:addagreedgrade');
         foreach ($managers as $manager) {
@@ -323,7 +323,7 @@ class cron {
                 // Already have this user.
                 continue;
             }
-            $result[$manager->id] = user::find($manager, false);
+            $result[$manager->id] = user::get_from_id($manager->id);
         }
         return array_values($result);
     }

--- a/classes/dates.php
+++ b/classes/dates.php
@@ -48,11 +48,10 @@ class dates extends activity_dates {
     protected function get_dates(): array {
         global $USER;
 
-        $instance = coursework::find($this->cm->instance);
+        $instance = coursework::get_from_id((int)$this->cm->instance);
         $timeopen = $instance->startdate ?? null;
         $timedue = $instance->get_user_deadline($USER->id) ?? null;
-
-        $user = user::find($USER->id);
+        $user = user::get_from_id((int)$USER->id);
         $deadlineextension = $user
             ? deadline_extension::get_extension_for_student($user, $instance) : null;
         if ($deadlineextension && ($deadlineextension->extended_deadline ?? null)) {

--- a/classes/export/csv/cells/agreedfeedback_cell.php
+++ b/classes/export/csv/cells/agreedfeedback_cell.php
@@ -79,8 +79,7 @@ class agreedfeedback_cell extends cell_base {
                 $PAGE->context
             )
         ) {
-            $subdbrecord = $DB->get_record('coursework_submissions', ['id' => $submissionid]);
-            $submission = submission::find($subdbrecord);
+            $submission = submission::get_from_id($submissionid);
 
             // Is the submission in question ready to grade?
             if (!$submission->all_initial_graded() && !empty($value)) {
@@ -117,7 +116,7 @@ class agreedfeedback_cell extends cell_base {
                 }
             } else {
                 // This is an existing feedback check it against the edit ability checks.
-                if (!$feedback->can_edit($this->coursework, submission::find($submissionid))) {
+                if (!$feedback->can_edit($this->coursework, submission::get_from_id($submissionid))) {
                     return get_string('nopermissiontoeditmark', 'coursework');
                 }
             }

--- a/classes/export/csv/cells/agreedgrade_cell.php
+++ b/classes/export/csv/cells/agreedgrade_cell.php
@@ -148,9 +148,7 @@ class agreedgrade_cell extends cell_base {
             if (!empty($errormsg)) {
                 return $errormsg;
             }
-
-            $subdbrecord = $DB->get_record('coursework_submissions', ['id' => $submissionid]);
-            $submission = submission::find($subdbrecord);
+            $submission = submission::get_from_id($submissionid);
 
             // Is the submission in question ready to grade?
             if (!$submission->all_initial_graded() && !empty($value) && count($uploadedgradecells) < $submission->max_number_of_feedbacks()) {

--- a/classes/export/csv/cells/assessorfeedback_cell.php
+++ b/classes/export/csv/cells/assessorfeedback_cell.php
@@ -95,11 +95,8 @@ class assessorfeedback_cell extends cell_base {
         }
         $agreedgradecap = ['mod/coursework:addagreedgrade', 'mod/coursework:editagreedgrade'];
         $initialgradecap = ['mod/coursework:addinitialgrade', 'mod/coursework:editinitialgrade'];
-
-        $subdbrecord = $DB->get_record('coursework_submissions', ['id' => $submissionid]);
-        $submission = submission::find($subdbrecord);
+        $submission = submission::get_from_id($submissionid);
         $administergrades = has_capability('mod/coursework:administergrades', $modulecontext);
-
         if (
             $administergrades
             ||

--- a/classes/export/csv/cells/assessorgrade_cell.php
+++ b/classes/export/csv/cells/assessorgrade_cell.php
@@ -109,10 +109,8 @@ class assessorgrade_cell extends cell_base {
 
         $agreedgradecap = ['mod/coursework:addagreedgrade', 'mod/coursework:editagreedgrade'];
         $initialgradecap = ['mod/coursework:addinitialgrade', 'mod/coursework:editinitialgrade'];
+        $submission = submission::get_from_id($submissionid);
         $administergrades = has_capability('mod/coursework:administergrades', $PAGE->context);
-        $subdbrecord = $DB->get_record('coursework_submissions', ['id' => $submissionid]);
-        $submission = submission::find($subdbrecord);
-
         if (
             $administergrades
             ||

--- a/classes/export/csv/cells/feedbackcomments_cell.php
+++ b/classes/export/csv/cells/feedbackcomments_cell.php
@@ -61,9 +61,7 @@ class feedbackcomments_cell extends cell_base {
         if (
             has_any_capability(['mod/coursework:addinitialgrade', 'mod/coursework:editinitialgrade', 'mod/coursework:administergrades'], $PAGE->context)
         ) {
-            $dbrecord = $DB->get_record('coursework_submissions', ['id' => $submissionid]);
-
-            $submission = submission::find($dbrecord);
+            $submission = submission::get_from_id($submissionid);
 
             // Is this submission ready to be graded
             if (!$submission->ready_to_grade()) {

--- a/classes/export/csv/cells/singlegrade_cell.php
+++ b/classes/export/csv/cells/singlegrade_cell.php
@@ -136,10 +136,7 @@ class singlegrade_cell extends cell_base {
             if (!empty($errormsg)) {
                 return $errormsg;
             }
-
-            $dbrecord = $DB->get_record('coursework_submissions', ['id' => $submissionid]);
-
-            $submission = submission::find($dbrecord);
+            $submission = submission::get_from_id($submissionid);
 
             // Is this submission ready to be graded
             if (!$submission->ready_to_grade() && $submission->get_state() < submission::FULLY_GRADED) {

--- a/classes/export/csv/cells/submissionfileid_cell.php
+++ b/classes/export/csv/cells/submissionfileid_cell.php
@@ -55,7 +55,7 @@ class submissionfileid_cell extends cell_base {
         if (empty($value)) {
             return 'No submission hash value entered';
         }
-        $submission = submission::find($submissionid);
+        $submission = submission::get_from_id($submissionid);
 
         if (get_config('mod_coursework', 'use_candidate_numbers_for_hidden_name')) {
             $expected = $this->get_candidate_number($submission->allocatableid) ?? get_string('hidden');

--- a/classes/export/grading_sheet.php
+++ b/classes/export/grading_sheet.php
@@ -27,6 +27,7 @@ use mod_coursework\models\allocation;
 use mod_coursework\models\coursework;
 use mod_coursework\models\group;
 use mod_coursework\models\submission;
+use mod_coursework\models\user;
 
 class grading_sheet extends csv {
     public function get_submissions($groupid = null, $selectedsubmissionids = '') {
@@ -163,14 +164,14 @@ class grading_sheet extends csv {
         $csvdata = [];
         // groups
         if ($this->coursework->is_configured_to_have_group_submissions()) {
-            $group = group::find($submission->allocatableid);
+            $group = group::get_from_id($submission->allocatableid);
             $csvdata[] = $this->add_cells_to_array($submission, $group, $this->csvcells);
         } else {
             // students
             $students = $submission->students_for_gradebook();
 
             foreach ($students as $student) {
-                $student = \mod_coursework\models\user::find($student);
+                $student = user::get_from_id($student->id);
                 $csvdata[] = $this->add_cells_to_array($submission, $student, $this->csvcells);
             }
         }

--- a/classes/export/import.php
+++ b/classes/export/import.php
@@ -312,9 +312,7 @@ class import extends grading_sheet {
 
                 $i++;
             }
-
-            $subdbrecord = $DB->get_record('coursework_submissions', ['id' => $submissionid]);
-            $submission = submission::find($subdbrecord);
+            $submission = submission::get_from_id($submissionid);
 
             // Is this submission graded? if yes did this user grade it?
 
@@ -662,11 +660,8 @@ class import extends grading_sheet {
      * @throws dml_exception
      */
     public function get_stageidentifier($submissionid, $cellidentifier) {
-
         global $DB, $USER;
-        $submission = $DB->get_record('coursework_submissions', ['id' => $submissionid]);
-
-        $submission = submission::find($submission);
+        $submission = submission::get_from_id($submissionid);
 
         // single marked - singlegrade - allocated/notallocated
         $stageidentifier = 'assessor_1';
@@ -754,9 +749,7 @@ class import extends grading_sheet {
      */
     public function auto_agreement($cwfeedbackid) {
         global $DB;
-
-        $feedback = $DB->get_record('coursework_feedbacks', ['id' => $cwfeedbackid]);
-        $feedback = feedback::find($feedback);
+        $feedback = feedback::get_from_id($cwfeedbackid);
 
         $autofeedbackclassname = '\mod_coursework\auto_grader\\' . $this->coursework->automaticagreementstrategy;
         /**

--- a/classes/external/clearannotations.php
+++ b/classes/external/clearannotations.php
@@ -67,7 +67,7 @@ class clearannotations extends external_api {
             ]
         );
 
-        $submission = submission::find($params['submissionid']);
+        $submission = submission::get_from_id($params['submissionid']);
         if (!$submission) {
             return [
                 'success' => false,

--- a/classes/external/delete_extension.php
+++ b/classes/external/delete_extension.php
@@ -57,7 +57,7 @@ class delete_extension extends external_api {
         $result = ['success' => false, 'message' => null];
 
         $params = self::validate_parameters(self::execute_parameters(), ['extensionid' => $extensionid]);
-        $extension = deadline_extension::find($params['extensionid']);
+        $extension = deadline_extension::get_from_id($params['extensionid']);
         if (!$extension) {
             return [
                 'success' => false,

--- a/classes/external/get_grading_table_row_data.php
+++ b/classes/external/get_grading_table_row_data.php
@@ -68,7 +68,7 @@ class get_grading_table_row_data extends external_api {
             ]
         );
 
-        $coursework = coursework::find($params['courseworkid']);
+        $coursework = coursework::get_from_id($params['courseworkid']);
         if (!$coursework) {
             return [
                 'success' => false,

--- a/classes/forms/deadline_extension_form.php
+++ b/classes/forms/deadline_extension_form.php
@@ -270,7 +270,7 @@ class deadline_extension_form extends dynamic_form {
         $extensionid = $datasource['extensionid'] ?? null;
         if ($extensionid && is_numeric($extensionid)) {
             // We are editing an existing extension.
-            $extension = deadline_extension::find($extensionid);
+            $extension = deadline_extension::get_from_id($extensionid);
             if ($extension) {
                 $this->extension = $extension;
             } else {
@@ -279,12 +279,12 @@ class deadline_extension_form extends dynamic_form {
             $this->allocatable = $this->extension->get_allocatable();
             $this->coursework = $this->extension->get_coursework();
         } else {
-            $coursework = coursework::find($datasource['coursework']->id ?? $datasource['courseworkid']);
+            $coursework = coursework::get_from_id($datasource['coursework']->id ?? $datasource['courseworkid']);
             $this->coursework = $coursework;
             $allocatabletype = $datasource['allocatabletype'];
             $allocatableid = $datasource['allocatableid'];
             $classname = "\\mod_coursework\\models\\$allocatabletype";
-            $this->allocatable = $classname::find($allocatableid);
+            $this->allocatable = $classname::get_from_id($allocatableid);
             if (!$this->allocatable) {
                 throw new invalid_parameter_exception("Allocatable ID $allocatableid not found");
             }

--- a/classes/forms/personaldeadline_form.php
+++ b/classes/forms/personaldeadline_form.php
@@ -75,15 +75,15 @@ class personaldeadline_form extends dynamic_form {
             $customdata['courseworkid'],
         );
         $this->existingdeadline = $existingdeadlinerecord
-            ? personaldeadline::find($existingdeadlinerecord)
+            ? personaldeadline::get_from_id($existingdeadlinerecord->id)
             : null;
 
         $this->allocatable = $this->existingdeadline
             ? $this->existingdeadline->get_allocatable()
             : (
             $customdata['allocatabletype'] == 'user'
-                    ? user::find($customdata['allocatableid'])
-                    : group::find($customdata['allocatableid'])
+                    ? user::get_from_id($customdata['allocatableid'])
+                    : group::get_from_id($customdata['allocatableid'])
             );
 
         $this->_form->addElement('hidden', 'allocatabletype');
@@ -239,7 +239,7 @@ class personaldeadline_form extends dynamic_form {
             return $this->coursework;
         } else {
             $datasource = $this->_customdata ?? $this->_ajaxformdata;
-            $this->coursework = coursework::find($datasource['courseworkid']);
+            $this->coursework = coursework::get_from_id($datasource['courseworkid']);
         }
         return $this->coursework;
     }

--- a/classes/forms/plagiarism_flagging_mform.php
+++ b/classes/forms/plagiarism_flagging_mform.php
@@ -158,7 +158,7 @@ class plagiarism_flagging_mform extends dynamic_form {
             if (!$submissionid) {
                 $submissionid = $this->get_flag()->get_submission()->id();
             }
-            $this->submission = submission::find($submissionid);
+            $this->submission = submission::get_from_id($submissionid);
         }
         return $this->submission;
     }
@@ -175,7 +175,7 @@ class plagiarism_flagging_mform extends dynamic_form {
             $flagid = ($this->_customdata['plagiarismflagid'] ?? null) ?? ($this->_ajaxformdata['plagiarismflagid'] ?? null);
             if ($flagid) {
                 // Maybe no flag exists yet, but set it if it does.
-                $this->plagiarismflag = plagiarism_flag::find($flagid);
+                $this->plagiarismflag = plagiarism_flag::get_from_id($flagid);
             }
         }
         return $this->plagiarismflag;

--- a/classes/forms/student_submission_form.php
+++ b/classes/forms/student_submission_form.php
@@ -181,13 +181,9 @@ class student_submission_form extends moodleform {
 
                         if (!empty($useridcommaseparatedlist)) {
                             $userids = explode(',', $useridcommaseparatedlist);
+                            $mailer = new mailer($coursework);
                             foreach ($userids as $u) {
-                                $notifyuser = $DB->get_record('user', ['id' => trim($u)]);
-                                $mailer = new mailer($coursework);
-
-                                if (!empty($notifyuser)) {
-                                    $mailer->send_submission_notification($notifyuser);
-                                }
+                                $mailer->send_submission_notification(trim($u));
                             }
                         }
                     }

--- a/classes/framework/ability.php
+++ b/classes/framework/ability.php
@@ -161,7 +161,7 @@ abstract class ability {
      */
     protected function get_user() {
         if ($this->user === null) {
-            $this->user = user::find($this->userid);
+            $this->user = user::get_from_id($this->userid);
         }
         return $this->user;
     }

--- a/classes/framework/table_base.php
+++ b/classes/framework/table_base.php
@@ -63,14 +63,35 @@ abstract class table_base {
     protected readonly int $id;
 
     /**
+     * Get an instance of the child object from its ID.
+     *
+     * @param int $id
+     * @return static
+     * @throws dml_exception|invalid_parameter_exception
+     */
+    public static function get_from_id(int $id, int $strictness = IGNORE_MISSING): ?static {
+        global $DB;
+        // Temporarily, this just refers on to the legacy method to get the object.
+        // (The legacy method will be deleted later when the caching work is completed).
+        $record = $DB->get_record(static::get_table_name(), ['id' => $id]);
+        if ($record) {
+            return self::find($record, false) ?: null;
+        }
+        if ($strictness == MUST_EXIST) {
+            throw new invalid_parameter_exception("Object ID $id not found for class " . static::class);
+        }
+        return null;
+    }
+
+    /**
      * Makes a new instance. Can be overridden to provide a factory
      *
      * @param stdClass|int|array $dbrecord
      * @param bool $reload
-     * @return bool|self
+     * @return bool|static
      * @throws dml_exception|invalid_parameter_exception
      */
-    public static function find($dbrecord, $reload = true): self|bool {
+    public static function find($dbrecord, $reload = true): static|bool {
 
         global $DB;
 
@@ -78,14 +99,9 @@ abstract class table_base {
             return false;
         }
 
-        $klass = get_called_class();
-
-        if (is_numeric($dbrecord) && $dbrecord > 0) {
-            $data = $DB->get_record(self::get_table_name(), ['id' => $dbrecord]);
-            if (!$data) {
-                return false;
-            }
-            return new $klass($data);
+        if (is_numeric($dbrecord)) {
+            debugging("Passing ID to find is deprecated.  Use get_from_id() instead");
+            return self::get_from_id($dbrecord);
         }
 
         $recordid = self::get_id_from_record($dbrecord);
@@ -121,7 +137,7 @@ abstract class table_base {
                 return false;
             }
         }
-        return new $klass($dbrecord);
+        return new static($dbrecord);
     }
 
     /**

--- a/classes/framework/table_base.php
+++ b/classes/framework/table_base.php
@@ -74,13 +74,14 @@ abstract class table_base {
         // Temporarily, this just refers on to the legacy method to get the object.
         // (The legacy method will be deleted later when the caching work is completed).
         $record = $DB->get_record(static::get_table_name(), ['id' => $id]);
+        $result = null;
         if ($record) {
-            return self::find($record, false) ?: null;
+            $result = self::find($record, false) ?: null;
         }
-        if ($strictness == MUST_EXIST) {
+        if ($strictness == MUST_EXIST && !$result) {
             throw new invalid_parameter_exception("Object ID $id not found for class " . static::class);
         }
-        return null;
+        return $result;
     }
 
     /**

--- a/classes/framework/test/table_base_test.php
+++ b/classes/framework/test/table_base_test.php
@@ -55,7 +55,7 @@ class framework_table_base_test extends advanced_testcase {
         ];
         $user = $generator->create_user($params);
 
-        $this->assertEquals($user->id, framework_user_table::find($user->id)->id);
+        $this->assertEquals($user->id, framework_user_table::get_from_id($user->id)->id);
     }
 
     public function test_find_when_true_with_other_param() {
@@ -88,7 +88,7 @@ class framework_table_base_test extends advanced_testcase {
     }
 
     public function test_find_when_false_and_zero_supplied() {
-        $this->assertFalse(framework_user_table::find(0));
+        $this->assertNull(framework_user_table::get_from_id(0));
     }
 
     public function test_exists_when_true() {

--- a/classes/grading_report.php
+++ b/classes/grading_report.php
@@ -83,8 +83,8 @@ class grading_report {
             $row = new grading_table_row_base(
                 $coursework,
                 $participant,
-                $extension ? deadline_extension::find($extension, false) : null,
-                $personaldeadline ? personaldeadline::find($personaldeadline, false) : null,
+                $extension ? deadline_extension::get_from_id($extension->id) : null,
+                $personaldeadline ? personaldeadline::get_from_id($personaldeadline->id) : null,
                 $allsubmissionfiles[$participant->type() . "-" . $participant->id()] ?? [],
             );
 

--- a/classes/mailer.php
+++ b/classes/mailer.php
@@ -222,7 +222,7 @@ class mailer {
 
         $subject = get_string('cron_email_subject', 'mod_coursework', $emaildata);
 
-        $student = user::find($user);
+        $student = user::get_from_id($user->id);
 
         $emaildata->name = $student->name();
         $textbody = get_string('cron_email_text', 'mod_coursework', $emaildata);
@@ -246,7 +246,7 @@ class mailer {
         return message_send($eventdata);
     }
 
-    public function send_submission_notification($userstonotify) {
+    public function send_submission_notification(int $useridtonotify) {
 
         global $CFG;
 
@@ -256,8 +256,10 @@ class mailer {
 
             $subject = get_string('submission_notification_subject', 'coursework', $emaildata->coursework_name);
 
-            $userstonotify = user::find($userstonotify);
-
+            $userstonotify = user::get_from_id($useridtonotify);
+            if (!$userstonotify) {
+                return;
+            }
             $emaildata->name = $userstonotify->name();
             $textbody = get_string('submission_notification_text', 'coursework', $emaildata);
             $htmlbody = get_string('submission_notification_html', 'coursework', $emaildata);

--- a/classes/models/allocation.php
+++ b/classes/models/allocation.php
@@ -80,7 +80,7 @@ class allocation extends table_base {
     public function get_coursework() {
 
         if (!isset($this->coursework)) {
-            $this->coursework = coursework::find($this->courseworkid);
+            $this->coursework = coursework::get_from_id($this->courseworkid);
         }
 
         return $this->coursework;

--- a/classes/models/coursework.php
+++ b/classes/models/coursework.php
@@ -909,7 +909,7 @@ class coursework extends table_base {
 
         foreach ($submissions as $submission) {
             // If allocations are in use, then we don't supply files that are not allocated.
-            $submission = submission::find($submission);
+            $submission = submission::get_from_id($submission->id);
 
             $files = $fs->get_area_files(
                 $context->id,
@@ -1398,7 +1398,7 @@ class coursework extends table_base {
             $params = ['userid' => $userid, 'courseid' => $this->get_course()->id];
         }
         $group = $DB->get_record_sql($sql, $params);
-        return group::find($group);
+        return $group ? group::get_from_id($group->id) : false;
     }
 
     /**
@@ -1844,7 +1844,7 @@ class coursework extends table_base {
 
             $groups = $DB->get_records_sql($sql, $params);
             foreach ($groups as $group) {
-                $group = group::find($group);
+                $group = group::get_from_id($group->id);
                 // Find out if members of this group can access this coursework, if group is left without members then remove it
                 $cm = $this->get_course_module();
                 $cmobject = $this->cm_object($cm);
@@ -1993,7 +1993,7 @@ class coursework extends table_base {
         );
 
         foreach ($submissions as &$submission) {
-            $submission = submission::find($submission);
+            $submission = submission::get_from_id($submission->id);
         }
 
         return $submissions;
@@ -2461,9 +2461,9 @@ class coursework extends table_base {
         $deadline = $this->deadline;
 
         if ($this->usegroups) {
-            $allocatable = group::find($allocatableid);
+            $allocatable = group::get_from_id($allocatableid);
         } else {
-            $allocatable = user::find($allocatableid);
+            $allocatable = user::get_from_id($allocatableid);
         }
 
         if ($this->personaldeadlines_enabled()) {
@@ -2491,9 +2491,9 @@ class coursework extends table_base {
      */
     public function get_allocatable_from_id($allocatableid): allocatable {
         if ($this->is_configured_to_have_group_submissions()) {
-            return group::find($allocatableid);
+            return group::get_from_id($allocatableid);
         } else {
-            return user::find($allocatableid);
+            return user::get_from_id($allocatableid);
         }
     }
 

--- a/classes/models/deadline_extension.php
+++ b/classes/models/deadline_extension.php
@@ -114,7 +114,7 @@ class deadline_extension extends table_base {
 
     public function get_allocatable() {
         $classname = "\\mod_coursework\\models\\{$this->allocatabletype}";
-        return $classname::find($this->allocatableid);
+        return $classname::get_from_id($this->allocatableid);
     }
 
     /**

--- a/classes/models/feedback.php
+++ b/classes/models/feedback.php
@@ -350,7 +350,7 @@ class feedback extends table_base {
             }
             if (!isset($this->submission)) {
                 // We still do not have submission so try to get it from DB using ID.
-                $submission = submission::find($this->submissionid) ?: null;
+                $submission = submission::get_from_id($this->submissionid) ?: null;
                 if ($submission) {
                     $this->set_submission($submission);
                 }

--- a/classes/models/group.php
+++ b/classes/models/group.php
@@ -91,7 +91,7 @@ class group extends table_base implements allocatable, moderatable {
         foreach ($members as $member) {
             // check is member has capability to submit in this coursework (to get rid of assessors if they are placed in the group)
             if (has_capability('mod/coursework:submit', $context, $member)) {
-                $memberobjects[] = user::find($member);
+                $memberobjects[] = user::get_from_id($member->id);
             }
         }
         return $memberobjects;

--- a/classes/models/moderation.php
+++ b/classes/models/moderation.php
@@ -139,7 +139,7 @@ class moderation extends table_base {
      */
     public function get_submission() {
         $feedback = $this->get_feedback();
-        $this->submission = submission::find($feedback->submissionid);
+        $this->submission = submission::get_from_id($feedback->submissionid);
 
         return $this->submission;
     }

--- a/classes/models/moderation_set_rule.php
+++ b/classes/models/moderation_set_rule.php
@@ -187,7 +187,7 @@ abstract class moderation_set_rule extends table_base implements renderable {
      */
     protected function get_coursework() {
         if (!isset($this->coursework)) {
-            $this->coursework = coursework::find($this->courseworkid);
+            $this->coursework = coursework::get_from_id($this->courseworkid);
         }
         return $this->coursework;
     }

--- a/classes/models/personaldeadline.php
+++ b/classes/models/personaldeadline.php
@@ -69,7 +69,7 @@ class personaldeadline extends table_base {
 
     public function get_allocatable() {
         $classname = "\\mod_coursework\\models\\{$this->allocatabletype}";
-        return $classname::find($this->allocatableid);
+        return $classname::get_from_id($this->allocatableid);
     }
 
     /**

--- a/classes/models/sample_set_rule.php
+++ b/classes/models/sample_set_rule.php
@@ -186,7 +186,7 @@ abstract class sample_set_rule extends table_base implements renderable {
      */
     protected function get_coursework() {
         if (!isset($this->coursework)) {
-            $this->coursework = coursework::find($this->courseworkid);
+            $this->coursework = coursework::get_from_id($this->courseworkid);
         }
         return $this->coursework;
     }

--- a/classes/personaldeadline/table/row/builder.php
+++ b/classes/personaldeadline/table/row/builder.php
@@ -107,7 +107,7 @@ class builder implements user_row {
     public function get_student_firstname() {
         $allocatable = $this->get_allocatable();
         if (empty($allocatable->firstname)) {
-            $this->allocatable = user::find($allocatable);
+            $this->allocatable = user::get_from_id($allocatable->id());
         }
 
         return $this->get_allocatable()->firstname;
@@ -121,7 +121,7 @@ class builder implements user_row {
     public function get_student_lastname() {
         $allocatable = $this->get_allocatable();
         if (empty($allocatable->lastname)) {
-            $this->allocatable = user::find($allocatable);
+            $this->allocatable = user::get_from_id($allocatable->id());
         }
 
         return $this->get_allocatable()->lastname;
@@ -135,7 +135,7 @@ class builder implements user_row {
     public function get_idnumber() {
         $allocatable = $this->get_allocatable();
         if (empty($allocatable->idnumber)) {
-            $this->allocatable = user::find($allocatable);
+            $this->allocatable = user::get_from_id($allocatable->id());
         }
 
         return $this->get_allocatable()->idnumber;
@@ -149,7 +149,7 @@ class builder implements user_row {
     public function get_email() {
         $allocatable = $this->get_allocatable();
         if (empty($allocatable->email)) {
-            $this->allocatable = user::find($allocatable);
+            $this->allocatable = user::get_from_id($allocatable->id());
         }
 
         return $this->get_allocatable()->email;

--- a/classes/render_helpers/grading_report/data/marking_cell_data.php
+++ b/classes/render_helpers/grading_report/data/marking_cell_data.php
@@ -324,7 +324,7 @@ class marking_cell_data extends cell_data_base {
         $finalgrade = $this->get_mark_for_feedback($finalfeedback, $canshow);
         // If this is an auto generated feedback, lasteditedbyuser will be zero.
         $assessorname = $finalfeedback->assessorid
-            ? user::find($finalfeedback->assessorid, false)->name()
+            ? user::get_from_id($finalfeedback->assessorid)->name()
             : get_string('automaticallyagreed', 'mod_coursework');
         return (object)[
             'mark' => (object)[

--- a/classes/services/submission_figures.php
+++ b/classes/services/submission_figures.php
@@ -41,7 +41,7 @@ class submission_figures {
      */
     public static function get_submissions_for_assessor(int $instance): array {
 
-        $coursework = coursework::find($instance);
+        $coursework = coursework::get_from_id($instance);
         $context = $coursework->get_context();
         $submissions = $coursework->get_all_submissions();
 
@@ -95,7 +95,7 @@ class submission_figures {
      * @throws \dml_exception
      */
     public static function calculate_needsgrading_for_assessor(int $instance): int {
-        $coursework = coursework::find($instance);
+        $coursework = coursework::get_from_id($instance);
         $context = $coursework->get_context();
 
         $addagreedgrade = has_capability('mod/coursework:addagreedgrade', $context);

--- a/classes/stages/base.php
+++ b/classes/stages/base.php
@@ -286,7 +286,7 @@ abstract class base {
             $users = get_enrolled_users($this->coursework->get_context(), $this->assessor_capability());
             $this->teachers = array_map(
                 function ($user) {
-                    return user::find($user, false);
+                    return user::get_from_id($user->id);
                 },
                 $users
             );

--- a/classes/task/enrol_task.php
+++ b/classes/task/enrol_task.php
@@ -52,7 +52,7 @@ class enrol_task extends scheduled_task {
 
         if (!empty($courseworkids)) {
             foreach ($courseworkids as $courseworkid) {
-                $coursework = coursework::find($courseworkid);
+                $coursework = coursework::get_from_id($courseworkid);
                 if (empty($coursework)) {
                     continue;
                 }

--- a/classes/task/unenrol_task.php
+++ b/classes/task/unenrol_task.php
@@ -51,7 +51,7 @@ class unenrol_task extends scheduled_task {
 
         if (!empty($courseworkids)) {
             foreach ($courseworkids as $courseworkid) {
-                $coursework = coursework::find($courseworkid);
+                $coursework = coursework::get_from_id($courseworkid);
                 if (empty($coursework)) {
                     continue;
                 }

--- a/classes/test_helpers/factory_mixin.php
+++ b/classes/test_helpers/factory_mixin.php
@@ -95,7 +95,7 @@ trait factory_mixin {
         $user = new stdClass();
         $user->firstname = 'Student';
         $rawstudent = $generator->create_user($user);
-        $this->student = user::find($rawstudent);
+        $this->student = user::get_from_id($rawstudent->id);
         $this->enrol_as_student($this->student);
 
         return $this->student;
@@ -111,7 +111,7 @@ trait factory_mixin {
 
         $user = new stdClass();
         $user->firstname = 'Other Student';
-        $this->otherstudent = user::find($generator->create_user($user));
+        $this->otherstudent = user::get_from_id($generator->create_user($user)->id);
         $this->enrol_as_student($this->otherstudent);
 
         return $this->otherstudent;
@@ -128,7 +128,7 @@ trait factory_mixin {
         $user = new stdClass();
         $user->firstname = 'Teacher';
         $dbrecord = $generator->create_user($user);
-        $this->teacher = user::find($dbrecord);
+        $this->teacher = user::get_from_id($dbrecord->id);
         $this->enrol_as_teacher($this->teacher);
 
         return $this->teacher;
@@ -144,7 +144,7 @@ trait factory_mixin {
 
         $user = new stdClass();
         $user->firstname = 'Other Teacher';
-        $this->otherteacher = user::find($generator->create_user($user));
+        $this->otherteacher = user::get_from_id($generator->create_user($user)->id);
         $this->enrol_as_teacher($this->otherteacher);
 
         return $this->otherteacher;
@@ -158,7 +158,7 @@ trait factory_mixin {
         $group = new stdClass();
         $group->name = 'My group';
         $group->courseid = $this->get_course()->id;
-        $this->group = group::find($generator->create_group($group));
+        $this->group = group::get_from_id($generator->create_group($group)->id);
 
         return $this->group;
     }
@@ -220,7 +220,7 @@ trait factory_mixin {
         $generator = $this->get_coursework_generator();
         $params['course'] = $this->get_course()->id;
         $module = $generator->create_instance($params);
-        $this->coursework = coursework::find($module->id);
+        $this->coursework = coursework::get_from_id($module->id);
         return $this->coursework;
     }
 

--- a/lib.php
+++ b/lib.php
@@ -117,11 +117,11 @@ function mod_coursework_pluginfile($course, $cm, $context, $filearea, $args, $fo
 
     require_login($course, false, $cm);
 
-    if (!$coursework = $DB->get_record('coursework', ['id' => $cm->instance])) {
+    if (!$coursework = coursework::get_from_id($cm->instance)) {
         return false;
     }
 
-    $ability = new ability($USER->id, coursework::find($coursework));
+    $ability = new ability($USER->id, $coursework);
 
     // From assessment send_file().
     require_once($CFG->dirroot . '/lib/filelib.php');
@@ -129,7 +129,7 @@ function mod_coursework_pluginfile($course, $cm, $context, $filearea, $args, $fo
     if (in_array($filearea, ['submission', 'submissionannotations'])) {
         $submissionid = (int)array_shift($args);
 
-        $submission = submission::find($submissionid);
+        $submission = submission::get_from_id($submissionid);
         if (!$submission) {
             return false;
         }
@@ -154,13 +154,13 @@ function mod_coursework_pluginfile($course, $cm, $context, $filearea, $args, $fo
             /**
              * @var feedback $feedback
              */
-            $feedback = feedback::find($feedbackid);
+            $feedback = feedback::get_from_id($feedbackid);
             if (!$feedback) {
                 return false;
             }
 
             if (!$ability->can('show', $feedback)) {
-                throw new access_denied(coursework::find($coursework));
+                throw new access_denied($coursework);
             }
 
             $relativepath = implode('/', $args);
@@ -229,7 +229,7 @@ function coursework_add_instance($formdata) {
     $DB->update_record('course_modules', $coursemodule);
 
     // Get all the other data e.g. coursemodule.
-    $coursework = coursework::find($returnid);
+    $coursework = coursework::get_from_id($returnid);
 
     // Create event for coursework deadline [due]
     if ($coursework && $coursework->deadline) {
@@ -271,9 +271,7 @@ function mod_coursework_core_calendar_is_event_visible(calendar_event $event): b
     global $DB, $USER;
 
     $cm = get_fast_modinfo($event->courseid)->instances['coursework'][$event->instance];
-
-    $dbcoursework = $DB->get_record('coursework', ['id' => $cm->instance]);
-    $coursework = coursework::find($dbcoursework);
+    $coursework = coursework::get_from_id($cm->instance);
 
     $cansubmit = $coursework->can_submit();
     $ismarker = $coursework->is_assessor($USER->id);
@@ -317,8 +315,7 @@ function mod_coursework_core_calendar_provide_event_action(
     $name = '';
     $itemcount = 0;
 
-    $dbcoursework = $DB->get_record('coursework', ['id' => $cm->instance]);
-    $coursework = coursework::find($dbcoursework);
+    $coursework = coursework::get_from_id($cm->instance);
 
     $student = $coursework->can_submit();
     $marker = $coursework->is_assessor($USER->id);
@@ -341,7 +338,7 @@ function mod_coursework_core_calendar_provide_event_action(
 
         $submissionurl = new moodle_url('/mod/coursework/view.php', ['id' => $cm->id]);
     } else if ($student) { // for students
-        $user = user::find($USER->id, false);
+        $user = user::find($USER, false);
         // if group cw check if student is in group, if not then don't display 'Add submission' link
         if ($coursework->is_configured_to_have_group_submissions() && !$coursework->get_coursework_group_from_user_id($user->id())) {
             $submissionurl = new moodle_url('/mod/coursework/view.php', ['id' => $cm->id]);
@@ -395,8 +392,7 @@ function mod_coursework_core_calendar_event_action_shows_item_count(calendar_eve
     $agreedgradingdueeventtype = ['agreedgradingdue'];
     $cm = get_fast_modinfo($event->courseid)->instances['coursework'][$event->instance];
 
-    $dbcoursework = $DB->get_record('coursework', ['id' => $cm->instance]);
-    $coursework = coursework::find($dbcoursework);
+    $coursework = coursework::get_from_id($cm->instance);
     $student = $coursework->can_submit();
 
     // For mod_coursework we use 'initialgrading' and 'agreedgrading' event type; item count should be shown if there is one or more item count and user is not a student.
@@ -425,7 +421,7 @@ function coursework_grade_item_update($coursework, $grades = null) {
     if (get_class($coursework) == 'stdClass') {
         // On activity rename, core will pass in stdClass object here.
         // Otherwise expect coursework or coursework_groups_decorator to be passed.
-        $coursework = coursework::find($coursework);
+        $coursework = coursework::get_from_id($coursework->id);
     }
 
     $courseid = $coursework->get_course_id();
@@ -597,7 +593,7 @@ function coursework_update_instance($coursework) {
     ) {
         // Fire an event to send emails to students affected by any deadline change.
 
-        $courseworkobj = coursework::find($coursework->id);
+        $courseworkobj = coursework::get_from_id($coursework->id);
 
         $params = [
             'context' => context_module::instance($courseworkobj->get_course_module()->id),
@@ -657,7 +653,7 @@ function coursework_update_instance($coursework) {
 function coursework_update_events($coursework, $eventtype) {
     global $DB;
 
-    $coursework = coursework::find($coursework->id);
+    $coursework = coursework::get_from_id($coursework->id);
 
     $params = ['modulename' => 'coursework', 'instance' => $coursework->id, 'eventtype' => $eventtype];
     if ($eventtype == coursework::COURSEWORK_EVENT_TYPE_DUE) {
@@ -874,7 +870,7 @@ function coursework_get_extra_capabilities() {
 function coursework_plagiarism_dates($cmid) {
 
     $cm = get_coursemodule_from_id('coursework', $cmid);
-    $coursework = coursework::find($cm->instance);
+    $coursework = coursework::get_from_id($cm->instance);
 
     $datesarray = ['timeavailable' => $coursework->timecreated];
     $datesarray['timedue'] = $coursework->deadline;
@@ -904,7 +900,7 @@ function coursework_extend_settings_navigation(settings_navigation $settings, na
 
     $context = $PAGE->context;
     $course = $PAGE->course;
-    $coursework = coursework::find($cm->instance);
+    $coursework = coursework::get_from_id($cm->instance);
 
     if (!$course) {
         return;
@@ -1114,7 +1110,7 @@ function coursework_send_deadline_changed_emails($eventdata) {
     // No need to send emails if none of the deadlines have changed.
     $counter = 0;
 
-    $coursework = coursework::find($eventdata->other['courseworkid']);
+    $coursework = coursework::get_from_id($eventdata->other['courseworkid']);
 
     if (empty($coursework) || !$coursework->is_coursework_visible()) { // check if coursework exists and is not hidden
         return true;
@@ -1233,7 +1229,7 @@ function coursework_records_to_menu($records, $field1, $field2) {
  */
 function coursework_mod_updated($eventdata) {
     if ($eventdata->other['modulename'] == 'coursework') {
-        $coursework = coursework::find($eventdata->other['instanceid']);
+        $coursework = coursework::get_from_id($eventdata->other['instanceid']);
         /**
          * @var coursework $coursework
          */
@@ -1265,7 +1261,7 @@ function course_group_member_added($eventdata) {
     $courseworks = $DB->get_records('coursework', ['course' => $courseid, 'assessorallocationstrategy' => 'group_assessor']);
 
     foreach ($courseworks as $coursework) {
-        $coursework = coursework::find($coursework);
+        $coursework = coursework::get_from_id($coursework->id);
         $stage = $coursework->marking_stages();
         $stage1 = $stage['assessor_1']; // this allocation is only for 1st stage, we don't touch other stages
         $student = $coursework->can_submit(); // check if user is student in this course
@@ -1280,7 +1276,7 @@ function course_group_member_added($eventdata) {
                 break;
             } else { // No - check if CW is a group coursework
                 if ($coursework->is_configured_to_have_group_submissions()) {// yes - assign the tutor to a allocatable group
-                    $stage1->make_auto_allocation_if_necessary(group::find($groupid));
+                    $stage1->make_auto_allocation_if_necessary(group::get_from_id($groupid));
                 } else {  // no, check if group has any student members
                     $allocatables = $coursework->get_allocatables();
                     if ($allocatables) {
@@ -1298,9 +1294,9 @@ function course_group_member_added($eventdata) {
             }
         } else if ($student) {
             if ($coursework->is_configured_to_have_group_submissions()) {
-                $allocatable = group::find($groupid);
+                $allocatable = group::get_from_id($groupid);
             } else {
-                $allocatable = user::find($addeduserid);
+                $allocatable = user::get_from_id($addeduserid);
             }
             // process allocatables (group or student) allocation
             $stage1->make_auto_allocation_if_necessary($allocatable);
@@ -1328,7 +1324,7 @@ function course_group_member_removed($eventdata) {
     $courseworks = $DB->get_records('coursework', ['course' => $courseid, 'assessorallocationstrategy' => 'group_assessor']);
 
     foreach ($courseworks as $coursework) {
-        $coursework = coursework::find($coursework);
+        $coursework = coursework::get_from_id($coursework->id);
         $stage = $coursework->marking_stages();
         $stage1 = $stage['assessor_1']; // this allocation is only for 1st stage, we don't touch other stages
 
@@ -1380,7 +1376,7 @@ function course_group_member_removed($eventdata) {
 
             if ($assessorsingroup) { // if another assessor found, assign all allocatables in this group to the other assessor
                 if ($coursework->is_configured_to_have_group_submissions()) {// yes - assign the assessor to a allocatable group
-                    $stage1->make_auto_allocation_if_necessary(group::find($groupid));
+                    $stage1->make_auto_allocation_if_necessary(group::get_from_id($groupid));
                 } else {
                     $allocatables = $coursework->get_allocatables();
                     if ($allocatables) {
@@ -1418,7 +1414,7 @@ function course_group_member_removed($eventdata) {
 
             // check if the student was in a different group and allocate them to the first found group
             if (!$coursework->is_configured_to_have_group_submissions()) {
-                $allocatable = user::find($allocatableid);
+                $allocatable = user::get_from_id($allocatableid);
                 if ($coursework->student_is_in_any_group($allocatable)) {
                     $stage1->make_auto_allocation_if_necessary($allocatable);
                 }
@@ -1569,15 +1565,15 @@ function teacher_removed_allocated_not_graded($eventdata) {
 
     $courseworks = coursework_get_courseworks_by_courseid($courseid);
     foreach ($courseworks as $cw) {
-        $coursework = coursework::find($cw->id);
+        $coursework = coursework::get_from_id($cw->id);
         if ($coursework->allocation_enabled()) {
             $assessorallocations = $DB->get_records('coursework_allocation_pairs', ['courseworkid' => $coursework->id,
                                                                                                 'assessorid' => $userid]);
             foreach ($assessorallocations as $allocation) {
                 if ($allocation->allocatabletype == 'user') {
-                    $allocatable = user::find($allocation->allocatableid);
+                    $allocatable = user::get_from_id($allocation->allocatableid);
                 } else {
-                    $allocatable = group::find($allocation->allocatableid);
+                    $allocatable = group::get_from_id($allocation->allocatableid);
                 }
 
                 $submission = $coursework->get_allocatable_submission($allocatable);

--- a/mod_form.php
+++ b/mod_form.php
@@ -233,7 +233,7 @@ class mod_coursework_mod_form extends moodleform_mod {
 
         $courseworkid = $this->get_courseworkid();
         if ($courseworkid) {
-            $coursework = mod_coursework\models\coursework::find($courseworkid);
+            $coursework = mod_coursework\models\coursework::get_from_id($courseworkid);
             if ($coursework->has_samples() && isset($data['samplingenabled']) && $data['samplingenabled'] == 0) {
                 $errors['samplingenabled'] = get_string('sampling_cant_be_disabled', 'mod_coursework');
             }
@@ -245,7 +245,7 @@ class mod_coursework_mod_form extends moodleform_mod {
 
         // Validate candidate number setting changes.
         if (!empty($this->_customdata['courseworkid'])) {
-            $coursework = coursework::find($this->_customdata['courseworkid']);
+            $coursework = coursework::get_from_id($this->_customdata['courseworkid']);
 
             if ($coursework && !$coursework->can_change_candidate_number_setting()) {
                 $currentvalue = $coursework->usecandidate ?? 0;
@@ -376,7 +376,7 @@ class mod_coursework_mod_form extends moodleform_mod {
         $optional = true;
         $courseworkid = $this->get_courseworkid();
         if ($courseworkid) {
-            $coursework = mod_coursework\models\coursework::find($courseworkid);
+            $coursework = mod_coursework\models\coursework::get_from_id($courseworkid);
             if ($coursework->extension_exists()) {
                 // An extension already exists for this coursework.
                 // So no longer possible to uncheck the box for coursework deadline - a deadline must apply.
@@ -1029,7 +1029,7 @@ class mod_coursework_mod_form extends moodleform_mod {
         $submissionexists = 0;
         // disable the setting if at least one submission exists
         $courseworkid = $this->get_courseworkid();
-        if ($courseworkid && mod_coursework\models\coursework::find($courseworkid)->has_any_submission()) {
+        if ($courseworkid && mod_coursework\models\coursework::get_from_id($courseworkid)->has_any_submission()) {
             $submissionexists = 1;
         }
 
@@ -1181,7 +1181,7 @@ class mod_coursework_mod_form extends moodleform_mod {
         $feedbackexists = 0;
         // disable the setting if at least one feedback exists
         $courseworkid = $this->get_courseworkid();
-        if ($courseworkid && mod_coursework\models\coursework::find($courseworkid)->has_any_final_feedback()) {
+        if ($courseworkid && mod_coursework\models\coursework::get_from_id($courseworkid)->has_any_final_feedback()) {
             $feedbackexists = 1;
         }
 
@@ -1263,7 +1263,7 @@ class mod_coursework_mod_form extends moodleform_mod {
         $moodleform->addHelpButton('samplingenabled', 'samplingenabled', 'mod_coursework');
 
         $courseworkid = $this->get_courseworkid();
-        if (!$courseworkid ||  ($courseworkid && !mod_coursework\models\coursework::find($courseworkid)->has_samples())) {
+        if (!$courseworkid ||  ($courseworkid && !mod_coursework\models\coursework::get_from_id($courseworkid)->has_samples())) {
             $moodleform->hideif('samplingenabled', 'numberofmarkers', 'eq', 1);
         }
     }
@@ -1411,7 +1411,7 @@ class mod_coursework_mod_form extends moodleform_mod {
      */
     protected function add_candidate_number_setting(): void {
         $moodleform =& $this->_form;
-        $coursework = $this->get_courseworkid() ? coursework::find($this->get_courseworkid()) : null;
+        $coursework = $this->get_courseworkid() ? coursework::get_from_id($this->get_courseworkid()) : null;
 
         // If new coursework, or can change setting, show as editable.
         if (!$coursework || $coursework->can_change_candidate_number_setting()) {

--- a/renderers/object_renderer.php
+++ b/renderers/object_renderer.php
@@ -393,7 +393,7 @@ class mod_coursework_object_renderer extends plugin_renderer_base {
      */
     protected function render_mod_coursework_coursework(mod_coursework_coursework $coursework): string {
         global $USER;
-        $student = user::find($USER, false);
+        $student = user::get_from_id($USER->id, false);
         $coursework = $coursework->wrapped_object();
         $template = new stdClass();
         $template->cmid = $coursework->get_coursemodule_id();
@@ -857,7 +857,7 @@ class mod_coursework_object_renderer extends plugin_renderer_base {
         $template = new stdClass();
 
         // Fetch student and deadline information.
-        $user = user::find($USER, false);
+        $user = user::get_from_id($USER->id);
 
         // Handle coursework deadline details.
         if ($coursework->has_deadline()) {
@@ -1013,7 +1013,7 @@ class mod_coursework_object_renderer extends plugin_renderer_base {
         $coursework = $personaldeadlinerow->get_coursework();
 
         $personaldeadline =
-            personaldeadline::get_personaldeadline_for_student(user::find($personaldeadlinerow->get_allocatable()->id()), $coursework);
+            personaldeadline::get_personaldeadline_for_student(user::get_from_id($personaldeadlinerow->get_allocatable()->id()), $coursework);
 
         if (!$personaldeadline) {
             $personaldeadline = personaldeadline::build(

--- a/renderers/page_renderer.php
+++ b/renderers/page_renderer.php
@@ -894,7 +894,7 @@ class mod_coursework_page_renderer extends plugin_renderer_base {
             if (!$cm->uservisible) {
                 continue;
             }
-            $coursework = coursework::find($cm->instance);
+            $coursework = coursework::get_from_id($cm->instance);
             if ($usesections && $cm->sectionnum) {
                 $sectionname = get_section_name($course, $sections[$cm->sectionnum]);
                 if ($sectionname !== $currentsection) {
@@ -915,7 +915,7 @@ class mod_coursework_page_renderer extends plugin_renderer_base {
                 if ($coursework->usegroups) {
                     $allocatable = $coursework->get_coursework_group_from_user_id($USER->id);
                 } else {
-                    $allocatable = user::find($USER->id, false);
+                    $allocatable = user::get_from_id($USER->id);
                 }
                 if ($allocatable) {
                     $timedue = $coursework->get_allocatable_deadline($allocatable->id); // get deadline based on user taking into considerations personal deadline and extension

--- a/tests/behat/behat_mod_coursework.php
+++ b/tests/behat/behat_mod_coursework.php
@@ -31,6 +31,7 @@ use mod_coursework\models\coursework;
 use mod_coursework\models\feedback;
 use mod_coursework\models\group;
 use mod_coursework\models\submission;
+use mod_coursework\models\user;
 use mod_coursework\router;
 use mod_coursework\stages\base as stage_base;
 use mod_coursework\auto_grader\average_grade_no_straddle;
@@ -1188,7 +1189,7 @@ class behat_mod_coursework extends behat_base {
 
         $coursework = new stdClass();
         $coursework->course = $this->course;
-        $this->coursework = coursework::find($generator->create_instance($coursework)->id);
+        $this->coursework = coursework::get_from_id($generator->create_instance($coursework)->id);
     }
 
     /**
@@ -2456,7 +2457,7 @@ class behat_mod_coursework extends behat_base {
         $user->firstname = $displayname ? $displayname : $rolename . $this->usersuffix;
         $user->lastname = $rolename . $this->usersuffix;
         $user = $generator->create_user($user);
-        $user = \mod_coursework\models\user::find($user);
+        $user = user::get_from_id($user->id);
 
         // If the role name starts with 'other_' here (e.g. 'other_teacher') we need to remove it.
         $rolename = str_replace('other_', '', $rolename);
@@ -2489,7 +2490,7 @@ class behat_mod_coursework extends behat_base {
         $group->name = 'My group';
         $group->courseid = $this->course->id;
         $group = $generator->create_group($group);
-        $this->group = group::find($group);
+        $this->group = group::get_from_id($group->id);
 
         $membership = new stdClass();
         $membership->groupid = $this->group->id;
@@ -3029,7 +3030,7 @@ class behat_mod_coursework extends behat_base {
             throw new ExpectationException('No submission found for student', $this->getsession());
         }
 
-        return submission::find($submissionrecord->id);
+        return submission::get_from_id($submissionrecord->id);
     }
 
     /**

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -109,7 +109,7 @@ class mod_coursework_generator extends testing_module_generator {
         }
 
         $instance = parent::create_instance($record, $options);
-        return coursework::find($instance);
+        return coursework::get_from_id($instance->id);
     }
 
     /**
@@ -231,7 +231,7 @@ class mod_coursework_generator extends testing_module_generator {
         if (!isset($submission->courseworkid) && isset($coursework)) {
             $submission->courseworkid = $coursework->id;
         } else if ($submission->courseworkid && !isset($coursework)) {
-            $coursework = coursework::find($submission->courseworkid);
+            $coursework = coursework::get_from_id($submission->courseworkid);
         } else if (!isset($submission->courseworkid) && !isset($coursework)) {
             throw new \core\exception\coding_exception('Coursework generator needs a courseworkid');
         }

--- a/tests/phpunit/allocation/assessment_set_membership_test.php
+++ b/tests/phpunit/allocation/assessment_set_membership_test.php
@@ -101,7 +101,7 @@ final class assessment_set_membership_test extends \advanced_testcase {
 
         $this->assertEquals(
             $membership,
-            assessment_set_membership::find($membership->id)
+            assessment_set_membership::get_from_id($membership->id)
         );
 
         $this->assertEquals(

--- a/tests/phpunit/backup/restore_date_test.php
+++ b/tests/phpunit/backup/restore_date_test.php
@@ -59,7 +59,7 @@ final class restore_date_test extends \restore_date_testcase {
         $data = new \stdClass();
         $data->courseworkid = $coursework->id;
         $data->userid = $user->id;
-        $submission = $generator->create_submission($data, coursework::find($coursework));
+        $submission = $generator->create_submission($data, coursework::get_from_id($coursework->id));
 
         $data = new \stdClass();
         $data->submissionid = $submission->id;

--- a/tests/phpunit/generator_test.php
+++ b/tests/phpunit/generator_test.php
@@ -82,7 +82,7 @@ final class generator_test extends \advanced_testcase {
         $this->assertEquals($course->id, $cm->course);
 
         $context = \context_module::instance($cm->id);
-        $this->assertEquals(coursework::find($coursework)->get_coursemodule_id(), $context->instanceid);
+        $this->assertEquals(coursework::get_from_id($coursework->id)->get_coursemodule_id(), $context->instanceid);
 
         // Test gradebook integration using low level DB access - DO NOT USE IN PLUGIN CODE!
         $gitem = $DB->get_record(
@@ -185,7 +185,7 @@ final class generator_test extends \advanced_testcase {
         $data->userid = $user->id;
 
         // Should fail because we have no assessorid and we have no logged ourselves in.
-        $submission = $generator->create_submission($data, coursework::find($coursework));
+        $submission = $generator->create_submission($data, coursework::get_from_id($coursework->id));
         $submission = $DB->get_record('coursework_submissions', ['id' => $submission->id]);
 
         $this->assertNotEmpty($submission);

--- a/tests/phpunit/models/group_test.php
+++ b/tests/phpunit/models/group_test.php
@@ -44,7 +44,7 @@ final class group_test extends \advanced_testcase {
         $group = $generator->create_group($group);
 
         $this->assertNotEmpty($group->name);
-        $courseworkgroup = group::find($group->id);
+        $courseworkgroup = group::get_from_id($group->id);
         $this->assertEquals($group->name, $courseworkgroup->name);
         $this->assertTrue($courseworkgroup->persisted());
     }

--- a/tests/phpunit/models/moderation_set_membership_test.php
+++ b/tests/phpunit/models/moderation_set_membership_test.php
@@ -41,6 +41,6 @@ final class moderation_set_membership_test extends \advanced_testcase {
         $record->courseworkid = 44;
         $membership = assessment_set_membership::create($record);
 
-        $this->assertEquals(22, \mod_coursework\models\assessment_set_membership::find($membership->id())->allocatableid);
+        $this->assertEquals(22, \mod_coursework\models\assessment_set_membership::get_from_id($membership->id())->allocatableid);
     }
 }

--- a/tests/phpunit/models/submission_test.php
+++ b/tests/phpunit/models/submission_test.php
@@ -96,7 +96,7 @@ final class submission_test extends \advanced_testcase {
         $submission->save();
         $this->assertTrue($submission->persisted());
 
-        $retrieved = submission::find($submission->id);
+        $retrieved = submission::get_from_id($submission->id);
         $this->assertequals($submission->id(), $retrieved->id());
 
         $this->assertEquals($this->coursework->id, $retrieved->courseworkid);
@@ -112,7 +112,7 @@ final class submission_test extends \advanced_testcase {
 
         $this->assertInstanceOf(
             '\mod_coursework\models\submission',
-            submission::find($submission->id)
+            submission::get_from_id($submission->id)
         );
     }
 

--- a/tests/phpunit/models/user_test.php
+++ b/tests/phpunit/models/user_test.php
@@ -43,7 +43,7 @@ final class user_test extends \advanced_testcase {
         $user = $this->getDataGenerator()->create_user();
 
         $this->assertNotEmpty($user->firstname);
-        $this->assertEquals($user->firstname, \mod_coursework\models\user::find($user->id)->firstname);
+        $this->assertEquals($user->firstname, \mod_coursework\models\user::get_from_id($user->id)->firstname);
     }
 
     public function test_has_final_agreed_grade_returns_true_when_present(): void {
@@ -131,7 +131,7 @@ final class user_test extends \advanced_testcase {
         $this->assertEquals($dbstudent->id, $courseworkuser2->id());
 
         // Find the user coursework object providing their ID.
-        $courseworkuser3 = user::find($dbstudent);
+        $courseworkuser3 = user::get_from_id($dbstudent->id);
         $this->assertNotFalse($courseworkuser3);
         $this->assertTrue($courseworkuser3->persisted());
         $this->assertEquals($dbstudent->id, $courseworkuser3->id());

--- a/view.php
+++ b/view.php
@@ -22,6 +22,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use core\exception\invalid_parameter_exception;
 use mod_coursework\event\course_module_viewed;
 use mod_coursework\export\csv;
 use mod_coursework\export\grading_sheet;
@@ -62,42 +63,19 @@ $group = optional_param('group', -1, PARAM_INT);
 $resettable = optional_param('treset', 0, PARAM_INT);
 $allresettable = optional_param('alltreset', 0, PARAM_INT);
 
-$courseworkrecord = new stdClass();
-
 if ($coursemoduleid) {
-    $coursemodule = get_coursemodule_from_id(
-        'coursework',
-        $coursemoduleid,
-        0,
-        false,
-        MUST_EXIST
-    );
-    $course = $DB->get_record('course', ['id' => $coursemodule->course], '*', MUST_EXIST);
+    [$course, $coursemodule] = get_course_and_cm_from_cmid($coursemoduleid);
     $courseworkid = $coursemodule->instance;
+} else if ($courseworkid) {
+    [$course, $coursemodule] = get_course_and_cm_from_instance($courseworkid, 'coursework');
 } else {
-    if ($courseworkid) {
-        $course = $DB->get_record(
-            'course',
-            ['id' => $courseworkrecord->course],
-            '*',
-            MUST_EXIST
-        );
-        $coursemodule = get_coursemodule_from_instance(
-            'coursework',
-            $courseworkid,
-            $course->id,
-            false,
-            MUST_EXIST
-        );
-    } else {
-        die('You must specify a course_module ID or an instance ID');
-    }
+    throw new invalid_parameter_exception('No course module ID or instance ID supplied');
 }
 
 // This will set $PAGE->context to the coursemodule's context.
 require_login($course, true, $coursemodule);
 
-$coursework = mod_coursework\models\coursework::get_from_id($courseworkid);
+$coursework = mod_coursework\models\coursework::get_from_id($courseworkid, MUST_EXIST);
 
 // Check if group is in session and use it no group available in url
 if (groups_get_activity_groupmode($coursework->get_course_module()) != 0 && $group == -1) {

--- a/view.php
+++ b/view.php
@@ -73,20 +73,9 @@ if ($coursemoduleid) {
         MUST_EXIST
     );
     $course = $DB->get_record('course', ['id' => $coursemodule->course], '*', MUST_EXIST);
-    $courseworkrecord = $DB->get_record(
-        'coursework',
-        ['id' => $coursemodule->instance],
-        '*',
-        MUST_EXIST
-    );
+    $courseworkid = $coursemodule->instance;
 } else {
     if ($courseworkid) {
-        $courseworkrecord = $DB->get_record(
-            'coursework',
-            ['id' => $courseworkid],
-            '*',
-            MUST_EXIST
-        );
         $course = $DB->get_record(
             'course',
             ['id' => $courseworkrecord->course],
@@ -95,7 +84,7 @@ if ($coursemoduleid) {
         );
         $coursemodule = get_coursemodule_from_instance(
             'coursework',
-            $courseworkrecord->id,
+            $courseworkid,
             $course->id,
             false,
             MUST_EXIST
@@ -108,7 +97,7 @@ if ($coursemoduleid) {
 // This will set $PAGE->context to the coursemodule's context.
 require_login($course, true, $coursemodule);
 
-$coursework = mod_coursework\models\coursework::find($courseworkrecord);
+$coursework = mod_coursework\models\coursework::get_from_id($courseworkid);
 
 // Check if group is in session and use it no group available in url
 if (groups_get_activity_groupmode($coursework->get_course_module()) != 0 && $group == -1) {
@@ -236,7 +225,7 @@ if ($canviewstudents) {
         /**
          * @var submission $submission
          */
-        $submission = submission::find($submissionid);
+        $submission = submission::get_from_id($submissionid);
 
         $params = [
             'cm' => $coursemodule->id,


### PR DESCRIPTION
This is a simple change but touches many files.  It introduces `table_base::get_from_id(int $id)` and replaces `table_base::find($id)` instances for that across multiple files.  This is to prepare the ground for a larger PR to replace the cache system and to make that subsequent PR easier to manage.  However this PR also makes sense on a standalone basis