### PR TITLE
CTP-6290 Fix task error $id must be of type int

### DIFF
--- a/classes/task/enrol_task.php
+++ b/classes/task/enrol_task.php
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace mod_coursework;
 namespace mod_coursework\task;
 
 use cache;
@@ -45,25 +44,15 @@ class enrol_task extends scheduled_task {
      * Run coursework cron.
      */
     public function execute() {
-
         global $DB;
 
-        $courseworkids = $DB->get_records('coursework', ['processenrol' => 1]);
+        foreach (coursework::find_all(['processenrol' => 1]) as $coursework) {
+            $cache = cache::make('mod_coursework', 'courseworkdata');
+            $cache->set($coursework->id() . "_teachers", '');
+            $allocator = new auto_allocator($coursework);
+            $allocator->process_allocations();
 
-        if (!empty($courseworkids)) {
-            foreach ($courseworkids as $courseworkid) {
-                $coursework = coursework::get_from_id($courseworkid);
-                if (empty($coursework)) {
-                    continue;
-                }
-
-                $cache = cache::make('mod_coursework', 'courseworkdata');
-                $cache->set($coursework->id() . "_teachers", '');
-                $allocator = new auto_allocator($coursework);
-                $allocator->process_allocations();
-
-                $DB->set_field('coursework', 'processenrol', 0, ['id' => $coursework->id()]);
-            }
+            $DB->set_field('coursework', 'processenrol', 0, ['id' => $coursework->id()]);
         }
 
         return true;

--- a/classes/task/unenrol_task.php
+++ b/classes/task/unenrol_task.php
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace mod_coursework\models;
 namespace mod_coursework\task;
 
 use core\task\scheduled_task;
@@ -44,23 +43,13 @@ class unenrol_task extends scheduled_task {
      * Run coursework cron.
      */
     public function execute() {
-
         global $DB;
 
-        $courseworkids = $DB->get_records('coursework', ['processunenrol' => 1]);
+        foreach (coursework::find_all(['processunenrol' => 1]) as $coursework) {
+            $allocator = new auto_allocator($coursework);
+            $allocator->process_allocations();
 
-        if (!empty($courseworkids)) {
-            foreach ($courseworkids as $courseworkid) {
-                $coursework = coursework::get_from_id($courseworkid);
-                if (empty($coursework)) {
-                    continue;
-                }
-
-                $allocator = new auto_allocator($coursework);
-                $allocator->process_allocations();
-
-                $DB->set_field('coursework', 'processunenrol', 0, ['id' => $coursework->id()]);
-            }
+            $DB->set_field('coursework', 'processunenrol', 0, ['id' => $coursework->id()]);
         }
 
         return true;

--- a/tests/phpunit/task_test.php
+++ b/tests/phpunit/task_test.php
@@ -1,0 +1,82 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Unit tests for mod/coursework/classes/task/enrol_task and unenrol_task.
+ *
+ * @package    mod_coursework
+ * @copyright  2026 onwards University College London {@link https://www.ucl.ac.uk/}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author     Leon Stringer <leon.stringer@ucl.ac.uk>
+ */
+
+namespace mod_coursework;
+
+use mod_coursework\task\enrol_task;
+use mod_coursework\task\unenrol_task;
+
+/**
+ * Unit tests for mod/coursework/lib.php.
+ *
+ * @copyright  2026 onwards University College London {@link https://www.ucl.ac.uk/}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class task_test extends \advanced_testcase {
+    /**
+     * Add a single record for the enrol task to process.
+     */
+    public function test_enrol_tasks(): void {
+        global $DB;
+
+        $this->resetAfterTest();
+        $this->setAdminUser();
+        $course = $this->getDataGenerator()->create_course();
+        $coursework = $this->getDataGenerator()->create_module('coursework', ['course' => $course->id]);
+
+        // Enrol teacher and check there is a processenrol record.
+        $teacher  = $this->getDataGenerator()->create_and_enrol($course, 'editingteacher');
+        $this->assertCount(1, $DB->get_records('coursework', ['processenrol' => 1]));
+
+        // Run task and check there are no processenrol records.
+        $task = new enrol_task();
+        $task->execute();
+        $this->assertCount(0, $DB->get_records('coursework', ['processenrol' => 1]));
+    }
+
+    /**
+     * Add a single record for the unenrol task to process.
+     */
+    public function test_unenrol_tasks(): void {
+        global $DB;
+
+        $this->resetAfterTest();
+        $this->setAdminUser();
+        $course = $this->getDataGenerator()->create_course();
+        $teacher  = $this->getDataGenerator()->create_and_enrol($course, 'editingteacher');
+        $coursework = $this->getDataGenerator()->create_module('coursework', ['course' => $course->id]);
+
+        // Unenrol teacher and check there is a processunenrol record.
+        $enrol = enrol_get_plugin('manual');
+        $manualenrol = $DB->get_record('enrol', ['courseid' => $course->id, 'enrol' => 'manual']);
+        $enrol->unenrol_user($manualenrol, $teacher->id);
+        $this->assertCount(1, $DB->get_records('coursework', ['processunenrol' => 1]));
+
+        // Run task and check there are no processunenrol records.
+        $task = new unenrol_task();
+        $task->execute();
+        $this->assertCount(0, $DB->get_records('coursework', ['processunenrol' => 1]));
+    }
+}


### PR DESCRIPTION
Fix the following error which occurred if enrol_task or unenrol_task had records to process:
  mod_coursework\framework\table_base::get_from_id(): Argument #1 ($id)
  must be of type int, stdClass given