### PR TITLE
CTP-6315 Allow extensions to be deleted

### DIFF
--- a/classes/external/delete_extension.php
+++ b/classes/external/delete_extension.php
@@ -66,7 +66,7 @@ class delete_extension extends external_api {
         }
         $coursework = $extension->get_coursework();
         $ability = $coursework ? new ability($USER->id, $coursework) : null;
-        if ($ability && $ability->can('update', $extension) && $extension->can_be_deleted()) {
+        if ($ability && $ability->can('update', $extension)) {
             $extension->delete();
             return [
                 'success' => true,

--- a/classes/forms/deadline_extension_form.php
+++ b/classes/forms/deadline_extension_form.php
@@ -221,20 +221,12 @@ class deadline_extension_form extends dynamic_form {
         global $CFG;
         $errors = [];
         if ($data['deleteextension'] ?? null == 1) {
-            if (!$this->extension->can_be_deleted()) {
-                $errors['deleteextension'] = get_string('extension_cannot_delete', 'mod_coursework');
-            } else {
-                // No validation needed - extension is not yet in use so can be deleted. Other fields don't need checking.
-                return [];
-            }
+            return [];
         }
         $maxdeadline = $CFG->coursework_max_extension_deadline ?? 0;
         $deadline = $this->get_user_latest_deadline();
 
         if ($data['extended_deadline']) {
-            if ($data['extended_deadline'] <= $deadline) {
-                $errors['extended_deadline'] = get_string('alert_validate_deadline', 'coursework');
-            }
             if ($maxdeadline && $data['extended_deadline'] >= strtotime("+$maxdeadline months", $deadline)) {
                 $errors['extended_deadline'] = get_string('alert_validate_deadline_months', 'coursework', $maxdeadline);
             }
@@ -356,16 +348,7 @@ class deadline_extension_form extends dynamic_form {
         $data->extrainformationformat = $data->extra_information['format'] ?? null;
 
         if ($data->deleteextension ?? null == 1) {
-            if (!$this->extension->can_be_deleted()) {
-                $errors[] = get_string('extension_cannot_delete', 'mod_coursework');
-                return [
-                    'success' => empty($errors),
-                    'resultcode' => 'cannotdelete',
-                    'message' => '',
-                    'errors' => $errors,
-                    'warnings' => $warnings,
-                ];
-            } else if ($data->suredelete ?? false) {
+            if ($data->suredelete ?? false) {
                 $ability->require_can('update', $this->extension);
                 $this->extension->delete();
                 return [

--- a/classes/models/deadline_extension.php
+++ b/classes/models/deadline_extension.php
@@ -183,31 +183,6 @@ class deadline_extension extends table_base {
     }
 
     /**
-     * Check if the current extension is already in use - if yes, block deletion.
-     * @return bool
-     * @throws \coding_exception
-     * @throws \dml_exception
-     */
-    public function can_be_deleted(): bool {
-        global $DB;
-        if (!$this->get_coursework()->deadline_has_passed()) {
-            // User is not yet using the extension.
-            return true;
-        }
-        $allocatable = $this->get_allocatable();
-        $params = [
-            'allocatableid' => $allocatable->id(),
-            'allocatabletype' => $allocatable->type(),
-            'courseworkid' => $this->coursework->id(),
-        ];
-        $personaldeadline = personaldeadline::find($DB->get_record('coursework_person_deadlines', $params)) ?? null;
-        if ($personaldeadline) {
-            return $personaldeadline->personaldeadline > time();
-        }
-        return false;
-    }
-
-    /**
      * Delete an extension.
      * @return void
      * @throws \coding_exception

--- a/lang/en/coursework.php
+++ b/lang/en/coursework.php
@@ -227,7 +227,6 @@ $string['extendbeforerevert'] = 'Unable to unfinalise the submission until a sub
 $string['extended_deadline'] = 'Extended deadline';
 $string['extension'] = 'Extension';
 $string['extension_adding'] = 'New deadline extension for \'{$a}\'';
-$string['extension_cannot_delete'] = 'You cannot delete extension which is is already in use.';
 $string['extension_delete'] = 'Delete this extension';
 $string['extension_deleted'] = 'Extension for \'{$a}\' deleted';
 $string['extension_editing'] = 'Editing deadline extension for \'{$a}\'';

--- a/tests/behat/deadline.feature
+++ b/tests/behat/deadline.feature
@@ -59,7 +59,7 @@ Feature: Deadlines extensions for submissions
     And I click on "Submission extension" "button"
     And I wait until the page is ready
     And I set the field "Extended deadline" to "##+2 weeks, 8:00 AM##"
-    And I click on "Save" "button" in the "Extended deadline" "dialogue"
+    When I click on "Save" "button" in the "Extended deadline" "dialogue"
     Then I should see "##+2 weeks##%d %B %Y, 8:00 AM##" in the "student student1" "table_row"
     When I am on the "Coursework" "coursework activity" page
     Then I should see "##+2 weeks##%d %B %Y, 8:00 AM##" in the "student student1" "table_row"
@@ -69,7 +69,30 @@ Feature: Deadlines extensions for submissions
     And I click on "Submission extension" "button"
     And I wait until the page is ready
     And I set the field "Extended deadline" to "##+3 weeks, 8:00 AM##"
-    And I click on "Save" "button" in the "Extended deadline" "dialogue"
+    When I click on "Save" "button" in the "Extended deadline" "dialogue"
     Then I should see "##+3 weeks##%d %B %Y, 8:00 AM##" in the "student student1" "table_row"
     When I am on the "Coursework" "coursework activity" page
-    And I should see "##+3 weeks##%d %B %Y, 8:00 AM##" in the "student student1" "table_row"
+    Then I should see "##+3 weeks##%d %B %Y, 8:00 AM##" in the "student student1" "table_row"
+
+    # Test existing extensions can be set to an earlier date
+    Given I press "Actions"
+    And I wait until the page is ready
+    And I click on "Submission extension" "button"
+    And I wait until the page is ready
+    And I set the field "Extended deadline" to "##+1 weeks, 8:00 AM##"
+    When I click on "Save" "button" in the "Extended deadline" "dialogue"
+    Then I should see "##+1 weeks##%d %B %Y, 8:00 AM##" in the "student student1" "table_row"
+    When I am on the "Coursework" "coursework activity" page
+    Then I should see "##+1 weeks##%d %B %Y, 8:00 AM##" in the "student student1" "table_row"
+
+    # Test extensions can be deleted
+    Given I press "Actions"
+    And I wait until the page is ready
+    And I click on "Submission extension" "button"
+    And I wait until the page is ready
+    And I click on "Delete this extension" "checkbox"
+    When I click on "Save" "button" in the "Extended deadline" "dialogue"
+    And I click on "Delete" "button" in the "Are you sure?" "dialogue"
+    Then I should not see "Extension" in the "student student1" "table_row"
+    When I am on the "Coursework" "coursework activity" page
+    Then I should not see "Extension" in the "student student1" "table_row"


### PR DESCRIPTION
Previously deadline extensions could not be deleted after the student's effective deadline had passed. Also extensions could only be increased. These restrictions have been removed. Managers should be able to edit and remove extensions at any point, even if there is a submission, and/or deadline has passed.


