### PR TITLE
CTP-5992 Fix moderation ready for release status

### DIFF
--- a/classes/render_helpers/grading_report/data/marking_cell_data.php
+++ b/classes/render_helpers/grading_report/data/marking_cell_data.php
@@ -184,15 +184,8 @@ class marking_cell_data extends cell_data_base {
         $marker->timemodified = $feedback->timemodified;
 
         if ($submission->persisted() && !$this->coursework->has_multiple_markers()) {
-            $showstatus = true;
-
-            if ($this->coursework->moderation_agreement_enabled()) {
-                $moderation = $this->coursework->get_moderator_marking_stage()->get_moderation($submission);
-                $showstatus = (!empty($moderation) && $moderation->agreement === 'agreed');
-            }
-
-            $marker->released = $showstatus && $submission->is_published();
-            $marker->readyforrelease = $showstatus && !$marker->released && $submission->ready_to_publish();
+            $marker->released = $submission->is_published();
+            $marker->readyforrelease = !$marker->released && $submission->ready_to_publish();
         }
 
         // Actions - show, edit.

--- a/tests/behat/moderation_view.feature
+++ b/tests/behat/moderation_view.feature
@@ -41,9 +41,9 @@ Feature: View moderation feedback
     Then I should see "Blah"
 
     When I am on the "Coursework" "coursework activity" page
-    And I should not see "Released" in the table row containing "John1"
-    And I should not see "Ready for release" in the table row containing "John1"
-    And I click on "Agree marking" "link"
+    Then I should not see "Released" in the table row containing "John1"
+    But I should see "Ready for release" in the table row containing "John1"
+    When I click on "Agree marking" "link"
     Then I should see "teacher teacher1" in the "[data-behat-markstage=\"assessor_1\"]" "css_element"
     And I should see "58" in the "[data-behat-markstage=\"assessor_1\"]" "css_element"
     And I should see "Blah" in the "[data-behat-markstage=\"assessor_1\"]" "css_element"


### PR DESCRIPTION
Previously when "Enable moderations agreement" was enabled "Ready for release" only showed where the moderator agreed, even though moderation is optional. Now "Ready for release" shows for all marked submissions.


