### PR TITLE
Ctp 6371 finalise bug single marking

### DIFF
--- a/classes/ability.php
+++ b/classes/ability.php
@@ -1077,8 +1077,20 @@ class ability extends framework\ability {
             function (feedback $feedback) {
                 $iscreator = $feedback->assessorid == $this->userid;
                 $stage = $feedback->get_stage();
-                return  $iscreator && ($feedback->get_submission()->editable_feedbacks_exist() || $feedback->get_submission()->editable_final_feedback_exist()
-                        && ((!$feedback->get_coursework()->has_multiple_markers() && $stage->is_initial_assesor_stage() ) || !$stage->is_initial_assesor_stage()));
+                return  $iscreator &&
+                    (
+                        $feedback->get_submission()->draft_feedback_exists() ||
+                        $feedback->get_submission()->editable_feedbacks_exist() ||
+                        $feedback->get_submission()->editable_final_feedback_exist() &&
+                        (
+                            (
+                                !$feedback->get_coursework()->has_multiple_markers() &&
+                                $stage->is_initial_assesor_stage()
+                            ) || !$stage->is_initial_assesor_stage()
+                        )
+                    );
+
+                // return $iscreator && $feedback->get_submission()->draft_feedback_exists();
             }
         );
     }

--- a/classes/ability.php
+++ b/classes/ability.php
@@ -1079,14 +1079,16 @@ class ability extends framework\ability {
                 if (!$feedback->assessorid == $this->userid) {
                     return false;
                 }
-                // Draft feedback.
-                if ($feedback->get_submission()->draft_feedback_exists()) {
+
+                if (
+                    // Draft feedback.
+                    $feedback->get_submission()->draft_feedback_exists() ||
+                    // Editable initial feedback.
+                    $feedback->get_submission()->editable_feedbacks_exist()
+                ){
                     return true;
                 }
-                // Editable initial feedback.
-                if ($feedback->get_submission()->editable_feedbacks_exist()) {
-                    return true;
-                }
+
                 // Editable final feedback.
                 if (!$feedback->get_submission()->editable_final_feedback_exist()) {
                     return false;

--- a/classes/ability.php
+++ b/classes/ability.php
@@ -1075,20 +1075,30 @@ class ability extends framework\ability {
             'edit',
             'mod_coursework\models\feedback',
             function (feedback $feedback) {
-                $iscreator = $feedback->assessorid == $this->userid;
+                // Can only edit own feedback.
+                if (!$feedback->assessorid == $this->userid) {
+                    return false;
+                }
+                // Draft feedback.
+                if ($feedback->get_submission()->draft_feedback_exists()) {
+                    return true;
+                }
+                // Editable initial feedback.
+                if ($feedback->get_submission()->editable_feedbacks_exist()) {
+                    return true;
+                }
+                // Editable final feedback.
+                if (!$feedback->get_submission()->editable_final_feedback_exist()) {
+                    return false;
+                }
+
+                // The feedback is final and editable if we reach here.
+                $issinglemarking = !$feedback->get_coursework()->has_multiple_markers();
                 $stage = $feedback->get_stage();
-                return  $iscreator &&
-                    (
-                        $feedback->get_submission()->draft_feedback_exists() ||
-                        $feedback->get_submission()->editable_feedbacks_exist() ||
-                        $feedback->get_submission()->editable_final_feedback_exist() &&
-                        (
-                            (
-                                !$feedback->get_coursework()->has_multiple_markers() &&
-                                $stage->is_initial_assesor_stage()
-                            ) || !$stage->is_initial_assesor_stage()
-                        )
-                    );
+                $isinitialstage = $stage->is_initial_assesor_stage();
+                // Single marking and feedback is initial stage, or double marking
+                // and feedback is not at the initial stage.
+                return ($issinglemarking && $isinitialstage) || !$isinitialstage;
             }
         );
     }

--- a/classes/ability.php
+++ b/classes/ability.php
@@ -1089,8 +1089,6 @@ class ability extends framework\ability {
                             ) || !$stage->is_initial_assesor_stage()
                         )
                     );
-
-                // return $iscreator && $feedback->get_submission()->draft_feedback_exists();
             }
         );
     }

--- a/classes/ability.php
+++ b/classes/ability.php
@@ -1085,7 +1085,7 @@ class ability extends framework\ability {
                     $feedback->get_submission()->draft_feedback_exists() ||
                     // Editable initial feedback.
                     $feedback->get_submission()->editable_feedbacks_exist()
-                ){
+                ) {
                     return true;
                 }
 

--- a/classes/models/submission.php
+++ b/classes/models/submission.php
@@ -655,16 +655,16 @@ class submission extends table_base implements renderable {
         }
 
         // Final grade is done.
-        $hasfinalfeedback = (bool)$this->get_final_feedback();
+        $finalfeedback = $this->get_final_feedback();
 
-        if ($hasfinalfeedback) {
+        if ($finalfeedback && !$this->draft_feedback_exists()) {
             return self::FINAL_GRADED;
         }
 
         // All feedbacks in.
         $countassessorfeedbacks = count($this->get_assessor_feedbacks());
         $maxfeedbacksreached = $countassessorfeedbacks >= $this->max_number_of_feedbacks();
-        if ($maxfeedbacksreached && !$this->editable_feedbacks_exist() && !$this->editable_final_feedback_exist()) {
+        if ($maxfeedbacksreached && !$this->any_editable_feedback_exists() && !$this->editable_final_feedback_exist()) {
             return self::FULLY_GRADED;
         }
 
@@ -1740,5 +1740,15 @@ class submission extends table_base implements renderable {
     public function reload($complainifnotfound = true) {
         $this->currentstate = null;
         return parent::reload($complainifnotfound);
+    }
+
+    /**
+     * Does draft feedback exist?
+     *
+     * @return bool
+     */
+    public function draft_feedback_exists(): bool {
+        $feedback = $this->get_final_feedback();
+        return $feedback && $feedback->stageidentifier != 'final_agreed_1' && !$feedback->finalised;
     }
 }

--- a/tests/behat/feedback_final_feedback_single_marking.feature
+++ b/tests/behat/feedback_final_feedback_single_marking.feature
@@ -1,0 +1,64 @@
+@mod @mod_coursework @mod_coursework_feedback_final_feedback_single_marking
+Feature: Adding and editing final feedback
+
+  In order to provide students with a fair final grade that combines the component grades
+  As a course leader
+  I want to be able to edit the final grade via a form
+
+  Background:
+    Given the following "course" exists:
+      | fullname  | Course 1 |
+      | shortname | C1       |
+    And the following "activities" exist:
+    |activity|course|name|numberofmarkers|
+    |coursework|C1  |Coursework1|1        |
+    |coursework|C1  |Coursework2|1        |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | teacher   | teacher1 | teacher1@example.com |
+      | student1 | student   | student1 | student1@example.com |
+      | manager1 | manager   | manager1 | manager1@example.com |
+    And the following "course enrolments" exist:
+      | user     | course | role    |
+      | teacher1 | C1     | teacher |
+      | manager1 | C1     | manager |
+      | student1 | C1     | student |
+    And the following "mod_coursework > submissions" exist:
+      | allocatable | coursework | finalisedstatus |
+      | student1    | Coursework1 | 1               |
+      | student1    | Coursework2 | 1               |
+    And the following "mod_coursework > feedbacks" exist:
+      | allocatable | coursework | assessor | stageidentifier | grade | feedbackcomment  |finalised |
+      | student1    | Coursework1 | teacher1 | assessor_1      | 57    | New comment here |0         |
+      | student1    | Coursework2 | teacher1 | assessor_1      | 67    | New comment here |1         |
+
+  @javascript
+  Scenario: Editing the final feedback grade via a draft state
+    Given I am on the "Coursework1" "coursework activity" page logged in as "teacher1"
+    And I should see "57" in the "[data-behat-markstage='1']" "css_element"
+    And I should see "Draft" in the "[data-behat-markstage='1']" "css_element"
+    And I should not see "Ready for release" in the "student1" "table_row"
+    And I should not see "Released" in the "student student1" "table_row"
+    And I click on "57" "link" in the "student student1" "table_row"
+    And I press "Save and finalise"
+    And I should see "Ready for release" in the "student1" "table_row"
+    And I should not see "Released" in the "student student1" "table_row"
+    And I should not see "Release the marks" in the "student student1" "table_row"
+
+  @javascript
+  Scenario: Setting and releasing the final feedback grade via a draft state
+    When I am on the "Coursework1" "coursework activity" page logged in as "manager1"
+    Then I should see "57" in the "[data-behat-markstage='1']" "css_element"
+    And I should see "Draft" in the "[data-behat-markstage='1']" "css_element"
+    And I should not see "Ready for release" in the "student1" "table_row"
+    And I should not see "Released" in the "student student1" "table_row"
+    And I click on "57" "link" in the "student student1" "table_row"
+    And I press "Save and finalise"
+    And I should see "Ready for release" in the "student1" "table_row"
+    And I should not see "Released" in the "student student1" "table_row"
+    And I follow "Release the marks"
+    And I press "Confirm"
+    And I should see "Released" in the "student1" "table_row"
+    And I should not see "Ready for release" in the "student1" "table_row"
+    And I should see "Released" in the "student1" "table_row"
+    And I should not see "Ready for release" in the "student1" "table_row"

--- a/tests/behat/feedback_final_feedback_single_marking.feature
+++ b/tests/behat/feedback_final_feedback_single_marking.feature
@@ -1,7 +1,7 @@
 @mod @mod_coursework @mod_coursework_feedback_final_feedback_single_marking
 Feature: Adding and editing final feedback
 
-  In order to provide students with a fair final grade that combines the component grades
+  In order to provide students with a single grade
   As a course leader
   I want to be able to edit the final grade via a form
 

--- a/tests/behat/feedback_final_feedback_single_marking.feature
+++ b/tests/behat/feedback_final_feedback_single_marking.feature
@@ -1,5 +1,5 @@
 @mod @mod_coursework @mod_coursework_feedback_final_feedback_single_marking
-Feature: Adding and editing final feedback
+Feature: Adding and editing feedback
 
   In order to provide students with a single grade
   As a course leader

--- a/tests/behat/feedback_final_feedback_single_marking.feature
+++ b/tests/behat/feedback_final_feedback_single_marking.feature
@@ -10,9 +10,8 @@ Feature: Adding and editing feedback
       | fullname  | Course 1 |
       | shortname | C1       |
     And the following "activities" exist:
-    |activity|course|name|numberofmarkers|
-    |coursework|C1  |Coursework1|1        |
-    |coursework|C1  |Coursework2|1        |
+      | activity   | course | name        | numberofmarkers |
+      | coursework | C1     | Coursework1 | 1               |
     And the following "users" exist:
       | username | firstname | lastname | email                |
       | teacher1 | teacher   | teacher1 | teacher1@example.com |
@@ -24,18 +23,16 @@ Feature: Adding and editing feedback
       | manager1 | C1     | manager |
       | student1 | C1     | student |
     And the following "mod_coursework > submissions" exist:
-      | allocatable | coursework | finalisedstatus |
+      | allocatable | coursework  | finalisedstatus |
       | student1    | Coursework1 | 1               |
-      | student1    | Coursework2 | 1               |
     And the following "mod_coursework > feedbacks" exist:
-      | allocatable | coursework | assessor | stageidentifier | grade | feedbackcomment  |finalised |
-      | student1    | Coursework1 | teacher1 | assessor_1      | 57    | New comment here |0         |
-      | student1    | Coursework2 | teacher1 | assessor_1      | 67    | New comment here |1         |
+      | allocatable | coursework  | assessor | stageidentifier | grade | feedbackcomment  | finalised |
+      | student1    | Coursework1 | teacher1 | assessor_1      | 57    | New comment here | 0         |
 
   @javascript
   Scenario: Editing the final feedback grade via a draft state
-    Given I am on the "Coursework1" "coursework activity" page logged in as "teacher1"
-    And I should see "57" in the "[data-behat-markstage='1']" "css_element"
+    When I am on the "Coursework1" "coursework activity" page logged in as "teacher1"
+    Then I should see "57" in the "[data-behat-markstage='1']" "css_element"
     And I should see "Draft" in the "[data-behat-markstage='1']" "css_element"
     And I should not see "Ready for release" in the "student1" "table_row"
     And I should not see "Released" in the "student student1" "table_row"

--- a/tests/behat/marking_summary_single.feature
+++ b/tests/behat/marking_summary_single.feature
@@ -37,6 +37,18 @@ Feature: When a coursework uses single marking the marking summary table should 
     And I should see "0" in the "Ready for release" "list_item"
     And I should see "0" in the "Released" "list_item"
 
+  Scenario: Teacher's view when submission is marked but in draft
+    Given the following "mod_coursework > submissions" exist:
+      | allocatable | coursework | finalisedstatus |
+      | student1    | Coursework | 1               |
+    And the following "mod_coursework > feedbacks" exist:
+      | allocatable | coursework | assessor | stageidentifier | grade | feedbackcomment  |
+      | student1    | Coursework | teacher1 | assessor_1      | 67    | New comment here |
+    And I am on the "Coursework" "coursework activity" page logged in as "teacher1"
+    Then I should see "1/1" in the "Submissions" "list_item"
+    And I should see "1" in the "Ready for release" "list_item"
+    And I should see "0" in the "Released" "list_item"
+
   Scenario: Teacher's view when submission is marked
     Given the following "mod_coursework > submissions" exist:
       | allocatable | coursework | finalisedstatus |
@@ -47,6 +59,18 @@ Feature: When a coursework uses single marking the marking summary table should 
     And I am on the "Coursework" "coursework activity" page logged in as "teacher1"
     Then I should see "1/1" in the "Submissions" "list_item"
     And I should see "1" in the "Ready for release" "list_item"
+    And I should see "0" in the "Released" "list_item"
+
+  Scenario: Managers's view when submission is marked but in draft
+    Given the following "mod_coursework > submissions" exist:
+      | allocatable | coursework | finalisedstatus |
+      | student1    | Coursework | 1               |
+    And the following "mod_coursework > feedbacks" exist:
+      | allocatable | coursework | assessor | stageidentifier | grade | feedbackcomment  |finalised|
+      | student1    | Coursework | teacher1 | assessor_1      | 67    | New comment here |0        |
+    And I am on the "Coursework" "coursework activity" page logged in as "manager1"
+    Then I should see "1/1" in the "Submissions" "list_item"
+    And I should see "0" in the "Ready for release" "list_item"
     And I should see "0" in the "Released" "list_item"
 
   Scenario: Manager's view when marks are released

--- a/tests/behat/plagiarism_turnitin_disabled.feature
+++ b/tests/behat/plagiarism_turnitin_disabled.feature
@@ -1,9 +1,9 @@
 @mod @mod_coursework @mod_coursework_plagiarism_turnitin_links
 Feature: Check that Turnitin functionality is not visible when disabled.
-#  These tests can be expected to fail if the plagiarism/turnitin plugin is not also installed in the build.
 
   Background:
-    Given the following "course" exists:
+    Given the plagiarism_turnitin plugin is installed
+    And the following "course" exists:
       | fullname  | Course 1 |
       | shortname | C1       |
     And the following "activity" exists:

--- a/tests/behat/plagiarism_turnitin_links.feature
+++ b/tests/behat/plagiarism_turnitin_links.feature
@@ -1,9 +1,9 @@
 @mod @mod_coursework @mod_coursework_plagiarism_turnitin_links
 Feature: Check that Turnitin reports are fetched and displayed post page load from JS (when enabled)
-#  These tests can be expected to fail if the plagiarism/turnitin plugin is not also installed in the build.
 
   Background:
-    Given the following config values are set as admin:
+    Given the plagiarism_turnitin plugin is installed
+    And the following config values are set as admin:
       | config                             | value | plugin              |
       | enableplagiarism                   | 1     |                     |
       | enabled                            | 1     | plagiarism_turnitin |


### PR DESCRIPTION
Fixed bug:
With a single-marked coursework there’s no way for a teacher to finalise their mark after saving it as draft. Also Ready for release is shown for the draft mark.