### PR TITLE
CTP-6338: Ensure order of assessor stage is preserved rendering marki…

### DIFF
--- a/renderers/page_renderer.php
+++ b/renderers/page_renderer.php
@@ -361,7 +361,7 @@ class mod_coursework_page_renderer extends plugin_renderer_base {
      * Agree feedback - output markers feedback in mustache.
      *
      * @param coursework $coursework
-     * @param array $previousfeedbacks Array of feedback objects.
+     * @param feedback[] $previousfeedbacks Array of feedback objects.
      * @param bool $isguide
      * @return string HTML.
      */
@@ -371,19 +371,19 @@ class mod_coursework_page_renderer extends plugin_renderer_base {
         $criteria = $isguide ? $gradingdefinition->guide_criteria : $gradingdefinition->rubric_criteria;
 
         $markersdata = [];
-        foreach ($previousfeedbacks as $index => $feedback) {
+        foreach ($previousfeedbacks as $feedback) {
             // Use controller to get instances for specific feedback.
             $instance = $gradingcontroller->get_current_instance($feedback->assessorid, $feedback->id);
 
             if ($instance) {
                 $filling = $isguide ? $instance->get_guide_filling() : $instance->get_rubric_filling();
-
                 $markerobj = new stdClass();
-                $markerobj->label = get_string('marker', 'mod_coursework') . " " . ($index + 1);
+                $markerobj->label = get_string('marker', 'mod_coursework') . " " . $feedback->get_assessor_stage_no();
                 $markerobj->fillings = $filling['criteria'] ?? [];
-                $markersdata[$index] = $markerobj;
+                $markersdata[$feedback->get_assessor_stage_no()] = $markerobj;
             }
         }
+        ksort($markersdata);
 
         $template = new stdClass();
         $template->reviewcriteria = [];


### PR DESCRIPTION
…ng guides

Annoyingly I couldn't work out the scenario that knocked them out of order, but this change both neatens up the code and guarantees they'll be correct. I tested by adding temporary code to intentionally flip them and then testing manually.


