### PR TITLE
CTP-6267: Fix personal deadline date in course section.

### DIFF
--- a/classes/models/coursework.php
+++ b/classes/models/coursework.php
@@ -1077,7 +1077,14 @@ class coursework extends table_base {
      * @return int
      */
     public function get_user_deadline($userid) {
-
+        // Does the user have a personal deadline to override the default?
+        if ($this->personaldeadlines_enabled()) {
+            $user = user::get_from_id((int)$userid);
+            $personaldeadline = personaldeadline::get_personaldeadline_for_student($user, $this);
+            if ($personaldeadline) {
+                return $personaldeadline->personaldeadline;
+            }
+        }
         return $this->deadline;
     }
 

--- a/tests/behat/personal_deadline.feature
+++ b/tests/behat/personal_deadline.feature
@@ -64,3 +64,20 @@ Feature: When "Use the personal deadline" is enabled the deadline date should re
     Then I am on the "Coursework" "coursework activity" page
     And I should see "Personal deadline" in the table row containing "John1"
     And I should see "##+2 weeks##%d %B %Y, 8:00 AM##" in the table row containing "John1"
+
+  @javascript
+  Scenario: Personal deadline should be reflected on course page
+    Given I am on the "Coursework" "coursework activity" page logged in as "manager1"
+    And I click on "Actions" "button" in the "John1" "table_row"
+    And I click on "Personal deadline" "button"
+    And I should see "New personal deadline for John1 student1"
+    And I set the field "Personal deadline" to "##+2 weeks, 8:00 AM##"
+    And I click on "Save" "button" in the "Personal deadline" "dialogue"
+    And I am on "C1" course homepage
+    And I navigate to "Settings" in current page administration
+    And I set the following fields to these values:
+      | Show activity dates | 1 |
+    And I press "Save and display"
+    When I log in as "student1"
+    And I am on "C1" course homepage
+    Then I should see "##+2 weeks##%d %B %Y, 8:00 AM##"


### PR DESCRIPTION
When the course has the "show activity dates" setting enabled the due date shown beneath the activity should reflect the user's personal deadline, if they have one set.


