### PR TITLE
CTP-6546: Fix logic around marker name/mark being shown when using sampling.

### DIFF
--- a/classes/ability.php
+++ b/classes/ability.php
@@ -182,7 +182,6 @@ class ability extends framework\ability {
         $this->allow_show_feedback_promoted_to_gradebook_when_grades_have_been_released();
         $this->allow_show_feedback_when_grades_released_and_students_can_view_all_feedbacks();
         $this->allow_show_feedback_if_user_can_view_grades_at_all_times_or_administer();
-        $this->allow_show_feedback_if_sampling_enabled_and_sample_marked();
 
         // Allocation rules
 
@@ -1165,7 +1164,7 @@ class ability extends framework\ability {
                             'mod/coursework:addallocatedagreedgrade',
                             'mod/coursework:addinitialgrade',
                             'mod/coursework:viewallgradesatalltimes',
-                            'mod/coursework:administergrades'
+                            'mod/coursework:administergrades',
                         ],
                         $feedback->get_coursework()->get_context()
                     )
@@ -1248,39 +1247,6 @@ class ability extends framework\ability {
                     ['mod/coursework:viewallgradesatalltimes', 'mod/coursework:administergrades'],
                     $feedback->get_coursework()->get_context()
                 );
-            }
-        );
-    }
-
-    /**
-     * If sampling is enabled, and the student is in the selected sample, and both the initial mark and the sample
-     * mark are completed, then we should be able to see it and the marker's details.
-     */
-    private function allow_show_feedback_if_sampling_enabled_and_sample_marked(): void {
-        $this->allow(
-            'show',
-            'mod_coursework\models\feedback',
-            function (feedback $feedback) {
-                if (
-                        !has_any_capability(
-                            ['mod/coursework:addinitialgrade', 'mod/coursework:addagreedgrade'],
-                            $feedback->get_coursework()->get_context()
-                        )
-                ) {
-                    return false;
-                }
-
-                // If we're using sampling, and some sampled feedback has been given.
-                // This might be assessor_2 or assessor_3. If sampling is enabled and there exists feedback for either
-                // of those stages, then we assume the sampling feedback has been given. I don't think it matters
-                // which one specifically it is.
-                if (
-                    $feedback->is_finalised() &&
-                    $this->get_coursework()->sampling_enabled() && $feedback->get_submission()->all_marking_is_complete()
-                ) {
-                    return true;
-                }
-                return false;
             }
         );
     }

--- a/classes/ability.php
+++ b/classes/ability.php
@@ -182,6 +182,7 @@ class ability extends framework\ability {
         $this->allow_show_feedback_promoted_to_gradebook_when_grades_have_been_released();
         $this->allow_show_feedback_when_grades_released_and_students_can_view_all_feedbacks();
         $this->allow_show_feedback_if_user_can_view_grades_at_all_times_or_administer();
+        $this->allow_show_feedback_if_sampling_enabled_and_sample_marked();
 
         // Allocation rules
 
@@ -1241,6 +1242,41 @@ class ability extends framework\ability {
                     ['mod/coursework:viewallgradesatalltimes', 'mod/coursework:administergrades'],
                     $feedback->get_coursework()->get_context()
                 );
+            }
+        );
+    }
+
+    /**
+     * If sampling is enabled, and the student is in the selected sample, and both the initial mark and the sample
+     * mark are completed, then we should be able to see it and the marker's details.
+     */
+    private function allow_show_feedback_if_sampling_enabled_and_sample_marked(): void {
+        $this->allow(
+            'show',
+            'mod_coursework\models\feedback',
+            function (feedback $feedback) {
+                if (
+                        !has_any_capability(
+                            ['mod/coursework:addinitialgrade', 'mod/coursework:addagreedgrade'],
+                            $feedback->get_coursework()->get_context()
+                        )
+                ) {
+                    return false;
+                }
+
+                // If we're using sampling, and some sampled feedback has been given.
+                // This might be assessor_2 or assessor_3. If sampling is enabled and there exists feedback for either
+                // of those stages, then we assume the sampling feedback has been given. I don't think it matters
+                // which one specifically it is.
+                if (
+                    $this->get_coursework()->sampling_enabled() && $feedback->get_submission()->stage_feedback_exists([
+                        'assessor_2',
+                        'assessor_3',
+                        ])
+                ) {
+                    return true;
+                }
+                return false;
             }
         );
     }

--- a/classes/ability.php
+++ b/classes/ability.php
@@ -177,7 +177,7 @@ class ability extends framework\ability {
         $this->allow_show_feedback_for_the_user_who_created_it();
         $this->allow_show_feedback_for_the_assessor_who_is_allocated_to_the_user();
         $this->allow_show_feedback_to_other_assessors_when_view_initial_grade_is_enabled();
-        $this->allow_show_feedback_to_agreed_graders_once_all_initial_grades_are_done();
+        $this->allow_show_feedback_once_all_initial_grades_are_done();
         $this->allow_show_feedback_once_agreed_grade_is_done();
         $this->allow_show_feedback_promoted_to_gradebook_when_grades_have_been_released();
         $this->allow_show_feedback_when_grades_released_and_students_can_view_all_feedbacks();
@@ -1153,14 +1153,20 @@ class ability extends framework\ability {
         );
     }
 
-    protected function allow_show_feedback_to_agreed_graders_once_all_initial_grades_are_done() {
+    protected function allow_show_feedback_once_all_initial_grades_are_done() {
         $this->allow(
             'show',
             'mod_coursework\models\feedback',
             function (feedback $feedback) {
                 return
                     has_any_capability(
-                        ['mod/coursework:addagreedgrade', 'mod/coursework:addallocatedagreedgrade'],
+                        [
+                            'mod/coursework:addagreedgrade',
+                            'mod/coursework:addallocatedagreedgrade',
+                            'mod/coursework:addinitialgrade',
+                            'mod/coursework:viewallgradesatalltimes',
+                            'mod/coursework:administergrades'
+                        ],
                         $feedback->get_coursework()->get_context()
                     )
                     &&
@@ -1269,10 +1275,8 @@ class ability extends framework\ability {
                 // of those stages, then we assume the sampling feedback has been given. I don't think it matters
                 // which one specifically it is.
                 if (
-                    $this->get_coursework()->sampling_enabled() && $feedback->get_submission()->stage_feedback_exists([
-                        'assessor_2',
-                        'assessor_3',
-                        ])
+                    $feedback->is_finalised() &&
+                    $this->get_coursework()->sampling_enabled() && $feedback->get_submission()->all_marking_is_complete()
                 ) {
                     return true;
                 }

--- a/classes/models/assessment_set_membership.php
+++ b/classes/models/assessment_set_membership.php
@@ -87,16 +87,7 @@ class assessment_set_membership extends table_base implements moderatable {
      */
     protected function post_save_hook() {
         self::remove_cache($this->courseworkid);
-    }
-
-    /**
-     * Allows subclasses to alter data before it hits the DB.
-     * @return void
-     * @throws \dml_exception
-     */
-    protected function pre_save_hook() {
         $this->membership_count_clear_cache_for_coursework();
-        parent::pre_save_hook();
     }
 
     /**

--- a/classes/models/feedback.php
+++ b/classes/models/feedback.php
@@ -594,4 +594,12 @@ class feedback extends table_base {
             ]);
         }
     }
+
+    /**
+     * Is the feedback finalised?
+     * @return bool
+     */
+    public function is_finalised(): bool {
+        return (int) $this->finalised === 1;
+    }
 }

--- a/classes/models/submission.php
+++ b/classes/models/submission.php
@@ -1291,6 +1291,21 @@ class submission extends table_base implements renderable {
         return false;
     }
 
+    public function all_marking_is_complete(): bool {
+        $feedbacks = $this->get_assessor_feedbacks();
+        if (count($feedbacks) < $this->max_number_of_feedbacks()) {
+            return false;
+        }
+
+        foreach ($feedbacks as $feedback) {
+            if (!$feedback->is_finalised()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     /**
      * How many feedbacks do we expect for this submission?
      * @return int

--- a/classes/models/submission.php
+++ b/classes/models/submission.php
@@ -1276,6 +1276,22 @@ class submission extends table_base implements renderable {
     }
 
     /**
+     * Check that feedback exists on this submission for a named stage.
+     * @param array $stageidentifiers Array of stages to check for feedback
+     * @param bool $finalised (default: true) Whether or not to only check for finalised ones.
+     * @return bool
+     */
+    public function stage_feedback_exists(array $stageidentifiers, bool $finalised = true): bool {
+        $feedback = $this->get_feedbacks();
+        foreach ($feedback as $f) {
+            if (in_array($f->stageidentifier, $stageidentifiers) && (!$finalised || $f->finalised)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * How many feedbacks do we expect for this submission?
      * @return int
      * @throws \core\exception\coding_exception

--- a/classes/models/submission.php
+++ b/classes/models/submission.php
@@ -1276,21 +1276,9 @@ class submission extends table_base implements renderable {
     }
 
     /**
-     * Check that feedback exists on this submission for a named stage.
-     * @param array $stageidentifiers Array of stages to check for feedback
-     * @param bool $finalised (default: true) Whether or not to only check for finalised ones.
+     * Has all required marking been completed and finalised?
      * @return bool
      */
-    public function stage_feedback_exists(array $stageidentifiers, bool $finalised = true): bool {
-        $feedback = $this->get_feedbacks();
-        foreach ($feedback as $f) {
-            if (in_array($f->stageidentifier, $stageidentifiers) && (!$finalised || $f->finalised)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     public function all_marking_is_complete(): bool {
         $feedbacks = $this->get_assessor_feedbacks();
         if (count($feedbacks) < $this->max_number_of_feedbacks()) {

--- a/classes/render_helpers/grading_report/data/marking_cell_data.php
+++ b/classes/render_helpers/grading_report/data/marking_cell_data.php
@@ -105,7 +105,7 @@ class marking_cell_data extends cell_data_base {
         $rowdata->countinitialfeedbacks = count(array_filter(
             $tablerows,
             function ($row) {
-                return $row->get_feedback() && !$row->get_feedback()->is_agreed_grade();
+                return $row->get_feedback() && !$row->get_feedback()->is_agreed_grade() && $row->get_feedback()->is_finalised();
             }
         ));
         $rowdata->hasallinitialfeedbacks = $rowdata->countinitialfeedbacks >= $this->coursework->get_max_markers();
@@ -115,20 +115,16 @@ class marking_cell_data extends cell_data_base {
             if ($row->get_stage()->identifier() === 'moderator') {
                 continue;
             }
-            $canseeothermarkerdetails = $rowdata->hasallinitialfeedbacks
-                || $this->coursework->viewinitialgradeenabled
-                || has_capability('mod/coursework:administergrades', $this->coursework->get_context());
-            $marker = $this->create_marker_data($row->get_assessorid(), $markernumber, $canseeothermarkerdetails);
 
             if ($feedback = $row->get_feedback()) {
                 $canseeothermarkerdetails = $feedback->can_show($feedback->get_coursework(), $submission);
-                $marker = $this->create_marker_data($row->get_assessor(), $markernumber, $canseeothermarkerdetails);
+                $marker = $this->create_marker_data($row->get_assessorid(), $markernumber, $canseeothermarkerdetails);
                 $this->process_feedback_data($marker, $feedback, $rowsbase, $row);
             } else {
                 $canseeothermarkerdetails = $rowdata->hasallinitialfeedbacks
                     || $this->coursework->viewinitialgradeenabled
                     || has_capability('mod/coursework:administergrades', $this->coursework->get_context());
-                $marker = $this->create_marker_data($row->get_assessor(), $markernumber, $canseeothermarkerdetails);
+                $marker = $this->create_marker_data($row->get_assessorid(), $markernumber, $canseeothermarkerdetails);
                 if (
                     isset($submission)
                     &&

--- a/classes/render_helpers/grading_report/data/marking_cell_data.php
+++ b/classes/render_helpers/grading_report/data/marking_cell_data.php
@@ -121,20 +121,28 @@ class marking_cell_data extends cell_data_base {
             $marker = $this->create_marker_data($row->get_assessorid(), $markernumber, $canseeothermarkerdetails);
 
             if ($feedback = $row->get_feedback()) {
+                $canseeothermarkerdetails = $feedback->can_show($feedback->get_coursework(), $submission);
+                $marker = $this->create_marker_data($row->get_assessor(), $markernumber, $canseeothermarkerdetails);
                 $this->process_feedback_data($marker, $feedback, $rowsbase, $row);
-            } else if (
-                isset($submission)
-                &&
-                feedback::can_add_new($rowsbase->get_coursework(), $submission, $row->get_stage()->identifier())
-            ) {
-                $marker->addfeedback = (object)[
-                    'markurl' => $this->get_mark_url(
-                        'new',
-                        $submission,
-                        $row->get_stage()
-                    ),
-                    'allocatablehash' => $this->get_allocatable_hash($allocatable),
-                ];
+            } else {
+                $canseeothermarkerdetails = $rowdata->hasallinitialfeedbacks
+                    || $this->coursework->viewinitialgradeenabled
+                    || has_capability('mod/coursework:administergrades', $this->coursework->get_context());
+                $marker = $this->create_marker_data($row->get_assessor(), $markernumber, $canseeothermarkerdetails);
+                if (
+                    isset($submission)
+                    &&
+                    feedback::can_add_new($rowsbase->get_coursework(), $submission, $row->get_stage()->identifier())
+                ) {
+                    $marker->addfeedback = (object)[
+                        'markurl' => $this->get_mark_url(
+                            'new',
+                            $submission,
+                            $row->get_stage()
+                        ),
+                        'allocatablehash' => $this->get_allocatable_hash($rowsbase->get_allocatable()),
+                    ];
+                }
             }
 
             $rowdata->markers[] = $marker;

--- a/tests/behat/blind_marking_visibility_for_agreed_graders_with_blind_marking.feature
+++ b/tests/behat/blind_marking_visibility_for_agreed_graders_with_blind_marking.feature
@@ -69,7 +69,7 @@ Feature: visibility of agreed graders with blind marking
     But I should see "Marked" in the "Hidden" "table_row"
     And I should see "67" in the "Hidden" "table_row"
     And I should see "teacher teacher1" in the "Hidden" "table_row"
-    And I should see "teacher teacher2" in the "Hidden" "table_row"
+    And I should not see "teacher teacher2" in the "Hidden" "table_row"
     When I click on "67" "link" in the "Hidden" "table_row"
     And I should see "New comment here"
 
@@ -78,7 +78,7 @@ Feature: visibility of agreed graders with blind marking
     And I should see "63" in the "Hidden" "table_row"
     But I should see "Marked" in the "Hidden" "table_row"
     And I should not see "67" in the "Hidden" "table_row"
-    And I should see "teacher teacher1" in the "Hidden" "table_row"
+    And I should not see "teacher teacher1" in the "Hidden" "table_row"
     And I should see "teacher teacher2" in the "Hidden" "table_row"
     When I click on "63" "link" in the "Hidden" "table_row"
     And I should see "New comment here"

--- a/tests/behat/blind_marking_visibility_for_agreed_graders_without_blind_marking.feature
+++ b/tests/behat/blind_marking_visibility_for_agreed_graders_without_blind_marking.feature
@@ -53,7 +53,7 @@ Feature: visibility of agreed graders without blind marking
     And I am on the "Coursework" "coursework activity" page logged in as "teacher2"
     Then I should see "63" in the "student student1" "table_row"
     And I should not see "67" in the "student student1" "table_row"
-    Then I should see "teacher teacher1" in the "student student1" "table_row"
+    Then I should not see "teacher teacher1" in the "student student1" "table_row"
     And I should see "teacher teacher2" in the "student student1" "table_row"
     Then I click on "63" "link" in the "student student1" "table_row"
     And I should see "New comment here"

--- a/tests/behat/feedback_viewinitialgrade.feature
+++ b/tests/behat/feedback_viewinitialgrade.feature
@@ -58,7 +58,7 @@ Feature: visibility for teachers without blind marking
       | student1    | Coursework | teacher1 | assessor_1      | 67    | New comment here | 0         |
       | student1    | Coursework | teacher2 | assessor_2      | 63    | New comment here | 0         |
     When I am on the "Coursework" "coursework activity" page logged in as "teacher2"
-    Then I should see "teacher teacher1" in the "student student1" "table_row"
+    Then I should not see "teacher teacher1" in the "student student1" "table_row"
     And I should see "teacher teacher2" in the "student student1" "table_row"
     And I should see "63" in the "student student1" "table_row"
     And I should not see "67" in the "student student1" "table_row"


### PR DESCRIPTION

- Fixes a cache issue which was causing incorrect feedback to be returned.
- Fixes logic as per description on ticket.
- Fixes behat tests which look like they were previously wrong.